### PR TITLE
Add AI Agent plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.php linguist-language=PHP
+*.js linguist-language=JavaScript
+*.css linguist-language=CSS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  php-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: PHP Lint
+        run: |
+          find . -name "*.php" -print0 | xargs -0 -n1 php -l
+      - name: Generate POT
+        run: |
+          if command -v wp >/dev/null 2>&1; then
+            wp i18n make-pot . languages/wp-ai-agent.pot
+          else
+            echo "WP-CLI not available";
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+vendor/
+.DS_Store
+*.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AI Agent Bot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -1,0 +1,11 @@
+#wp-ai-agent-root, #wp-ai-agent-admin { position: fixed; bottom: 20px; right: 20px; z-index: 99999; }
+.ai-agent-button { background:#25D366;color:#fff;border-radius:50%;width:56px;height:56px;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.2); }
+.ai-agent-window { display:none; flex-direction:column; width:400px; height:600px; background:#fff; border:1px solid #ccc; border-radius:8px; overflow:hidden; }
+.ai-agent-header { background:#075e54; color:#fff; padding:10px; }
+.ai-agent-messages { flex:1; overflow-y:auto; padding:10px; background:url('../img/wallpaper.svg'); }
+.ai-agent-input { display:flex; }
+.ai-agent-input textarea { flex:1; }
+.ai-agent-msg.user { background:#DCF8C6; align-self:flex-end; }
+.ai-agent-msg.bot { background:#fff; align-self:flex-start; }
+.ai-agent-msg { padding:6px 8px; margin:4px; border-radius:6px; max-width:80%; }
+@media (max-width:767px){ .ai-agent-window{ width:100%; height:100vh; border-radius:0; right:0; bottom:0; }}

--- a/wp-ai-agent/assets/icons/icons.svg
+++ b/wp-ai-agent/assets/icons/icons.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"><symbol id="chat" viewBox="0 0 24 24"><path d="M2 2h20v14H6l-4 4V2z" fill="#fff" stroke="#000"/></symbol></svg>

--- a/wp-ai-agent/assets/img/agent.svg
+++ b/wp-ai-agent/assets/img/agent.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="50" fill="#25D366"/></svg>

--- a/wp-ai-agent/assets/img/wallpaper.svg
+++ b/wp-ai-agent/assets/img/wallpaper.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" fill="none"><rect width="160" height="160" fill="#E5DDD5"/><path d="M0 80h160M80 0v160" stroke="#DDD"/></svg>

--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -1,0 +1,18 @@
+(function($){
+    function uuidv4(){return'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){var r=Math.random()*16|0,v=c=='x'?r:(r&0x3|0x8);return v.toString(16);});}
+    var vid=document.cookie.match(/ai_agent_vid=([^;]+)/);if(!vid){vid=uuidv4();document.cookie='ai_agent_vid='+vid+';path=/;max-age='+(365*24*60*60);}else{vid=vid[1];}
+    var root=document.getElementById('wp-ai-agent-root');
+    if(!root){root=document.getElementById('wp-ai-agent-admin');}
+    if(!root)return;
+    var btn=document.createElement('div');btn.className='ai-agent-button';btn.innerHTML='<svg width="24" height="24"><use href="'+wpAiAgent.assets+'/icons/icons.svg#chat"/></svg>';
+    var win=document.createElement('div');win.className='ai-agent-window';win.innerHTML='<div class="ai-agent-header">AI Agent</div><div class="ai-agent-messages"></div><div class="ai-agent-input"><textarea rows="2"></textarea><button>Send</button></div>';
+    root.appendChild(btn);root.appendChild(win);
+    var open=false;btn.addEventListener('click',function(){win.style.display=open?'none':'flex';open=!open;});
+    var ta=win.querySelector('textarea');var send=win.querySelector('button');
+    function addMsg(role,text){var m=document.createElement('div');m.className='ai-agent-msg '+role;m.textContent=text;win.querySelector('.ai-agent-messages').appendChild(m);win.querySelector('.ai-agent-messages').scrollTop=999999;}
+    function renderQuote(q){var card=document.createElement('pre');card.className='ai-agent-quote';card.textContent=JSON.stringify(q,null,2);win.querySelector('.ai-agent-messages').appendChild(card);}
+    send.addEventListener('click',function(){var msg=ta.value.trim();if(!msg)return;ta.value='';addMsg('user',msg);sendMsg(msg);});
+    if(wpAiAgent.enterSend){ta.addEventListener('keydown',function(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send.click();}});}
+    var convo=[];
+    function sendMsg(msg){var data=new FormData();data.append('action','ai_agent_chat');data.append('visitor',vid);data.append('message',msg);data.append('conversation',JSON.stringify(convo));fetch(wpAiAgent.ajax,{method:'POST',body:data}).then(function(res){var reader=res.body.getReader();var decoder=new TextDecoder();var out='';function read(){reader.read().then(function(r){if(r.done){convo.push({role:'user',content:msg});convo.push({role:'assistant',content:out});try{var q=JSON.parse(out);if(q.items){renderQuote(q);out='';}}catch(e){}addMsg('bot',out);return;}var str=decoder.decode(r.value);str.split('\n').forEach(function(line){if(line.startsWith('data:')){var payload=line.replace('data:','').trim();if(payload==='[DONE]'){return;}try{var j=JSON.parse(payload);if(j.choices&&j.choices[0].delta&&j.choices[0].delta.content){out+=j.choices[0].delta.content;}}catch(e){}}});read();});}read();});}
+})(jQuery);

--- a/wp-ai-agent/includes/class-ai-agent-admin.php
+++ b/wp-ai-agent/includes/class-ai-agent-admin.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Admin interface.
+ */
+
+class Ai_Agent_Admin {
+    public function __construct() {
+        add_action( 'admin_menu', [ $this, 'menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+    }
+
+    public function menu() {
+        add_menu_page(
+            __( 'AI Agent', 'wp-ai-agent' ),
+            __( 'AI Agent', 'wp-ai-agent' ),
+            'manage_options',
+            'wp-ai-agent',
+            [ $this, 'render_page' ],
+            'dashicons-format-chat'
+        );
+    }
+
+    public function register_settings() {
+        register_setting( 'wp_ai_agent', 'wp_ai_agent_settings', [ $this, 'sanitize_settings' ] );
+        register_setting( 'wp_ai_agent', 'wp_ai_agent_remove_uploads' );
+    }
+
+    public function sanitize_settings( $input ) {
+        $out = [];
+        $out['openai_key'] = wp_ai_agent_encrypt( sanitize_text_field( $input['openai_key'] ?? '' ) );
+        $out['alt_key']    = wp_ai_agent_encrypt( sanitize_text_field( $input['alt_key'] ?? '' ) );
+        $out['base_url']   = esc_url_raw( $input['base_url'] ?? '' );
+        $out['model']      = sanitize_text_field( $input['model'] ?? '' );
+        $out['quote_rules']= wp_kses_post( $input['quote_rules'] ?? '' );
+        $out['retention']  = isset( $input['retention'] ) ? (int) $input['retention'] : 30;
+        $out['enter_send'] = ! empty( $input['enter_send'] ) ? 1 : 0;
+        $out['debug']      = ! empty( $input['debug'] ) ? 1 : 0;
+        $out['sound']      = ! empty( $input['sound'] ) ? 1 : 0;
+        $out['remove']     = ! empty( $input['remove'] ) ? 1 : 0;
+        return $out;
+    }
+
+    public function render_page() {
+        $tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'api';
+        echo '<div class="wrap"><h1>' . esc_html__( 'AI Agent', 'wp-ai-agent' ) . '</h1>';
+        echo '<h2 class="nav-tab-wrapper">';
+        $tabs = [
+            'api'       => __( 'API Settings', 'wp-ai-agent' ),
+            'handbooks' => __( 'AI Handbook', 'wp-ai-agent' ),
+            'history'   => __( 'Chat History', 'wp-ai-agent' ),
+            'test'      => __( 'Test Chat', 'wp-ai-agent' ),
+        ];
+        foreach ( $tabs as $id => $label ) {
+            $class = ( $id === $tab ) ? ' nav-tab-active' : '';
+            echo '<a class="nav-tab' . esc_attr( $class ) . '" href="?page=wp-ai-agent&tab=' . esc_attr( $id ) . '">' . esc_html( $label ) . '</a>';
+        }
+        echo '</h2>';
+        switch ( $tab ) {
+            case 'handbooks':
+                include WP_AI_AGENT_DIR . 'templates/admin-handbooks.php';
+                break;
+            case 'history':
+                include WP_AI_AGENT_DIR . 'templates/admin-history.php';
+                break;
+            case 'test':
+                include WP_AI_AGENT_DIR . 'templates/admin-test-chat.php';
+                break;
+            case 'api':
+            default:
+                include WP_AI_AGENT_DIR . 'templates/admin-settings.php';
+                break;
+        }
+        echo '</div>';
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * AJAX proxy for chat.
+ */
+
+class Ai_Agent_AJAX {
+    public function __construct() {
+        add_action( 'wp_ajax_ai_agent_chat', [ $this, 'chat' ] );
+        add_action( 'wp_ajax_nopriv_ai_agent_chat', [ $this, 'chat' ] );
+    }
+
+    protected function rate_limit( $visitor_id ) {
+        $key = 'ai_agent_last_' . $visitor_id;
+        $last = get_transient( $key );
+        if ( $last ) {
+            wp_send_json_error( [ 'error' => 'rate_limited' ], 429 );
+        }
+        set_transient( $key, time(), 2 );
+    }
+
+    public function chat() {
+        nocache_headers();
+        $visitor = sanitize_text_field( $_POST['visitor'] ?? '' );
+        $message = sanitize_textarea_field( $_POST['message'] ?? '' );
+        $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+        $this->rate_limit( $visitor );
+
+        $settings = wp_ai_agent_get_settings();
+        $handbook = Ai_Agent_Handbooks::get_prompt();
+        $system = $handbook;
+        if ( ! empty( $settings['quote_rules'] ) ) {
+            $system .= "\nQuote rules:\n" . $settings['quote_rules'];
+        }
+        $messages = [ [ 'role' => 'system', 'content' => $system ] ];
+        foreach ( $conversation as $c ) {
+            $messages[] = [ 'role' => $c['role'], 'content' => $c['content'] ];
+        }
+        $messages[] = [ 'role' => 'user', 'content' => $message ];
+
+        header( 'Content-Type: text/event-stream' );
+        header( 'Cache-Control: no-cache' );
+        header( 'X-Accel-Buffering: no' );
+
+        $response = $this->stream_api( $settings, $messages );
+
+        Ai_Agent_DB::save_chat( $visitor, array_merge( $conversation, [ [ 'role' => 'user', 'content' => $message, 'ts' => time() ], [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ] ] ) );
+        wp_die();
+    }
+
+    protected function stream_api( $settings, $messages ) {
+        $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
+        $open = wp_ai_agent_decrypt( $settings['openai_key'] );
+        $model = $settings['model'] ?: 'gpt-4o-mini';
+        $url = $alt ? 'https://api.probex.top/v1/chat/completions' : 'https://api.openai.com/v1/chat/completions';
+        if ( ! empty( $settings['base_url'] ) && ! $alt ) {
+            $url = $settings['base_url'];
+        }
+        $headers = [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . ( $alt ? $alt : $open ),
+        ];
+        $body = [
+            'model'    => $alt ? $model : $model,
+            'messages' => $messages,
+            'stream'   => true,
+        ];
+        $ch = curl_init( $url );
+        curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
+        curl_setopt( $ch, CURLOPT_POST, true );
+        curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
+        curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
+        $buffer = '';
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+            $buffer .= $data;
+            echo $data;
+            @ob_flush();
+            flush();
+            return strlen( $data );
+        } );
+        curl_exec( $ch );
+        curl_close( $ch );
+        $text = '';
+        foreach ( explode( "\\n", $buffer ) as $line ) {
+            if ( 0 === strpos( $line, 'data:' ) ) {
+                $payload = trim( substr( $line, 5 ) );
+                if ( '[DONE]' === $payload ) {
+                    break;
+                }
+                $json = json_decode( $payload, true );
+                if ( isset( $json['choices'][0]['delta']['content'] ) ) {
+                    $text .= $json['choices'][0]['delta']['content'];
+                }
+            }
+        }
+        return $text;
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Database utilities.
+ */
+
+class Ai_Agent_DB {
+    public static function table_name() {
+        global $wpdb;
+        return $wpdb->prefix . 'ai_agent_chats';
+    }
+
+    public static function create_tables() {
+        global $wpdb;
+        $table = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE $table (\n            id INT NOT NULL AUTO_INCREMENT,\n            visitor_id VARCHAR(64) NOT NULL,\n            timestamp DATETIME NOT NULL,\n            conversation LONGTEXT NOT NULL,\n            PRIMARY KEY  (id),\n            KEY visitor_id (visitor_id)\n        ) $charset;";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    public static function drop_tables() {
+        global $wpdb;
+        $table = self::table_name();
+        $wpdb->query( "DROP TABLE IF EXISTS $table" );
+    }
+
+    public static function save_chat( $visitor_id, $conversation ) {
+        global $wpdb;
+        $wpdb->insert( self::table_name(), [
+            'visitor_id'  => $visitor_id,
+            'timestamp'   => current_time( 'mysql' ),
+            'conversation'=> wp_json_encode( $conversation ),
+        ] );
+    }
+
+    public static function get_chats() {
+        global $wpdb;
+        return $wpdb->get_results( "SELECT * FROM " . self::table_name() . " ORDER BY timestamp DESC" );
+    }
+
+    public static function delete_chat( $id ) {
+        global $wpdb;
+        $wpdb->delete( self::table_name(), [ 'id' => (int) $id ] );
+    }
+
+    public static function schedule_cron() {
+        if ( ! wp_next_scheduled( 'wp_ai_agent_retention_event' ) ) {
+            wp_schedule_event( time(), 'daily', 'wp_ai_agent_retention_event' );
+        }
+        add_action( 'wp_ai_agent_retention_event', [ __CLASS__, 'purge_old_chats' ] );
+    }
+
+    public static function clear_cron() {
+        $ts = wp_next_scheduled( 'wp_ai_agent_retention_event' );
+        if ( $ts ) {
+            wp_unschedule_event( $ts, 'wp_ai_agent_retention_event' );
+        }
+    }
+
+    public static function purge_old_chats() {
+        $settings = wp_ai_agent_get_settings();
+        $days = isset( $settings['retention'] ) ? (int) $settings['retention'] : 30;
+        if ( $days <= 0 ) {
+            return;
+        }
+        global $wpdb;
+        $cutoff = gmdate( 'Y-m-d H:i:s', time() - DAY_IN_SECONDS * $days );
+        $wpdb->query( $wpdb->prepare( "DELETE FROM " . self::table_name() . " WHERE timestamp < %s", $cutoff ) );
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-elementor.php
+++ b/wp-ai-agent/includes/class-ai-agent-elementor.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Elementor integration.
+ */
+
+class Ai_Agent_Elementor {
+    public function __construct() {
+        add_action( 'elementor/widgets/widgets_registered', [ $this, 'register_widget' ] );
+    }
+
+    public function register_widget() {
+        if ( ! did_action( 'elementor/loaded' ) ) {
+            return;
+        }
+        require_once WP_AI_AGENT_DIR . 'templates/widget-template.php';
+        \Elementor\Plugin::instance()->widgets_manager->register( new Ai_Agent_Elementor_Widget() );
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-encryption.php
+++ b/wp-ai-agent/includes/class-ai-agent-encryption.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Encryption helpers.
+ */
+
+class Ai_Agent_Encryption {
+    protected static function get_key() {
+        $key = defined( 'AUTH_KEY' ) ? AUTH_KEY : wp_salt( 'auth' );
+        return hash( 'sha256', $key, true );
+    }
+
+    public static function encrypt( $plain ) {
+        if ( empty( $plain ) ) {
+            return '';
+        }
+        $iv = random_bytes( 16 );
+        $cipher = openssl_encrypt( $plain, 'AES-256-CBC', self::get_key(), 0, $iv );
+        return base64_encode( $iv . $cipher );
+    }
+
+    public static function decrypt( $encoded ) {
+        if ( empty( $encoded ) ) {
+            return '';
+        }
+        $data = base64_decode( $encoded );
+        $iv = substr( $data, 0, 16 );
+        $cipher = substr( $data, 16 );
+        return openssl_decrypt( $cipher, 'AES-256-CBC', self::get_key(), 0, $iv );
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-handbooks.php
+++ b/wp-ai-agent/includes/class-ai-agent-handbooks.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Handbook management.
+ */
+
+class Ai_Agent_Handbooks {
+    protected static $cache = null;
+
+    public function __construct() {
+        add_action( 'admin_post_ai_agent_upload', [ $this, 'handle_upload' ] );
+        add_action( 'admin_post_ai_agent_delete_handbook', [ $this, 'handle_delete' ] );
+    }
+
+    public function handle_upload() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die();
+        }
+        check_admin_referer( 'ai_agent_upload' );
+        if ( empty( $_FILES['handbook']['name'] ) ) {
+            wp_safe_redirect( wp_get_referer() );
+            exit;
+        }
+        $file = $_FILES['handbook'];
+        $dir = wp_get_upload_dir();
+        $folder = trailingslashit( $dir['basedir'] ) . 'ai-agent-handbooks/';
+        wp_mkdir_p( $folder );
+        $dest = $folder . sanitize_file_name( $file['name'] );
+        move_uploaded_file( $file['tmp_name'], $dest );
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+
+    public function handle_delete() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die();
+        }
+        check_admin_referer( 'ai_agent_delete' );
+        $file = sanitize_file_name( $_GET['file'] ?? '' );
+        $dir = wp_get_upload_dir();
+        $folder = trailingslashit( $dir['basedir'] ) . 'ai-agent-handbooks/';
+        $path = $folder . $file;
+        if ( is_file( $path ) ) {
+            unlink( $path );
+        }
+        wp_safe_redirect( wp_get_referer() );
+        exit;
+    }
+
+    public static function get_prompt() {
+        if ( self::$cache !== null ) {
+            return self::$cache;
+        }
+        $dir = wp_get_upload_dir();
+        $folder = trailingslashit( $dir['basedir'] ) . 'ai-agent-handbooks/';
+        $summary = '';
+        if ( is_dir( $folder ) ) {
+            foreach ( glob( $folder . '*', GLOB_NOSORT ) as $file ) {
+                $summary .= self::summarize_file( $file ) . "\n";
+            }
+        }
+        if ( empty( trim( $summary ) ) ) {
+            $summary = 'You are a helpful assistant.';
+        }
+        self::$cache = substr( $summary, 0, 4000 );
+        return self::$cache;
+    }
+
+    protected static function summarize_file( $path ) {
+        $ext = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+        $content = '';
+        if ( 'txt' === $ext ) {
+            $content = file_get_contents( $path );
+        } elseif ( 'pdf' === $ext ) {
+            // Very naive PDF extraction.
+            if ( function_exists( 'shell_exec' ) ) {
+                $content = shell_exec( 'pdftotext ' . escapeshellarg( $path ) . ' -' );
+            }
+        } elseif ( 'docx' === $ext ) {
+            $zip = new ZipArchive();
+            if ( $zip->open( $path ) === true ) {
+                $data = $zip->getFromName( 'word/document.xml' );
+                $zip->close();
+                $content = strip_tags( $data );
+            }
+        }
+        if ( ! $content ) {
+            return '';
+        }
+        $content = preg_replace( '/\s+/', ' ', $content );
+        return substr( $content, 0, 1000 );
+    }
+}

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Frontend rendering.
+ */
+
+class Ai_Agent_Render {
+    public function __construct() {
+        add_action( 'wp_enqueue_scripts', [ $this, 'assets' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'admin_assets' ] );
+        add_action( 'wp_footer', [ $this, 'container' ] );
+    }
+
+    public function assets() {
+        wp_register_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
+        wp_register_script( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/js/chat.js', [ 'jquery' ], WP_AI_AGENT_VERSION, true );
+        $settings = wp_ai_agent_get_settings();
+        wp_localize_script( 'wp-ai-agent', 'wpAiAgent', [
+            'ajax'      => admin_url( 'admin-ajax.php' ),
+            'assets'    => WP_AI_AGENT_URL . 'assets',
+            'enterSend' => ! empty( $settings['enter_send'] ),
+            'sound'     => ! empty( $settings['sound'] ),
+            'debug'     => ! empty( $settings['debug'] ),
+        ] );
+        wp_enqueue_style( 'wp-ai-agent' );
+        wp_enqueue_script( 'wp-ai-agent' );
+    }
+
+    public function admin_assets( $hook ) {
+        if ( 'toplevel_page_wp-ai-agent' !== $hook ) {
+            return;
+        }
+        $this->assets();
+    }
+
+    public function container() {
+        echo '<div id="wp-ai-agent-root" aria-live="polite"></div>';
+    }
+}

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Helper functions.
+ */
+
+if ( ! function_exists( 'wp_ai_agent_get_settings' ) ) {
+    function wp_ai_agent_get_settings() {
+        $defaults = [
+            'openai_key' => '',
+            'alt_key'    => '',
+            'base_url'   => 'https://api.openai.com/v1/chat/completions',
+            'model'      => 'gpt-4o-mini',
+            'quote_rules'=> '',
+        ];
+        $opts = get_option( 'wp_ai_agent_settings', [] );
+        return wp_parse_args( $opts, $defaults );
+    }
+}
+
+if ( ! function_exists( 'wp_ai_agent_encrypt' ) ) {
+    function wp_ai_agent_encrypt( $value ) {
+        return Ai_Agent_Encryption::encrypt( $value );
+    }
+}
+
+if ( ! function_exists( 'wp_ai_agent_decrypt' ) ) {
+    function wp_ai_agent_decrypt( $value ) {
+        return Ai_Agent_Encryption::decrypt( $value );
+    }
+}

--- a/wp-ai-agent/readme.txt
+++ b/wp-ai-agent/readme.txt
@@ -1,0 +1,23 @@
+=== AI Agent (Chat + Quotes) ===
+Contributors: aibot
+Tags: ai, chat, quotes
+Requires at least: 6.4
+Tested up to: 6.4
+Requires PHP: 8.1
+Stable tag: 1.0.0
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+
+WhatsApp-style AI chat with quote generation.
+
+== Description ==
+AI Agent adds a floating WhatsApp-like chat widget that talks to OpenAI or Probex and can return structured quote JSON.
+
+== Installation ==
+1. Upload the plugin to `/wp-content/plugins/`.
+2. Activate through the Plugins menu.
+3. Configure under **AI Agent > API Settings**.
+
+== Changelog ==
+= 1.0.0 =
+* Initial release.

--- a/wp-ai-agent/templates/admin-handbooks.php
+++ b/wp-ai-agent/templates/admin-handbooks.php
@@ -1,0 +1,18 @@
+<?php
+$dir = wp_get_upload_dir();
+$folder = trailingslashit( $dir['basedir'] ) . 'ai-agent-handbooks/';
+$files = is_dir( $folder ) ? glob( $folder . '*', GLOB_NOSORT ) : [];
+?>
+<h2><?php _e( 'Upload Handbook', 'wp-ai-agent' ); ?></h2>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" enctype="multipart/form-data">
+<?php wp_nonce_field( 'ai_agent_upload' ); ?>
+<input type="hidden" name="action" value="ai_agent_upload" />
+<input type="file" name="handbook" />
+<?php submit_button( __( 'Upload', 'wp-ai-agent' ) ); ?>
+</form>
+<h2><?php _e( 'Existing Handbooks', 'wp-ai-agent' ); ?></h2>
+<ul>
+<?php foreach ( $files as $file ) : $name = basename( $file ); ?>
+<li><?php echo esc_html( $name ); ?> <a href="<?php echo wp_nonce_url( admin_url( 'admin-post.php?action=ai_agent_delete_handbook&file=' . urlencode( $name ) ), 'ai_agent_delete' ); ?>"><?php _e( 'Remove', 'wp-ai-agent' ); ?></a></li>
+<?php endforeach; ?>
+</ul>

--- a/wp-ai-agent/templates/admin-history.php
+++ b/wp-ai-agent/templates/admin-history.php
@@ -1,0 +1,39 @@
+<?php
+if ( isset( $_GET['export'] ) ) {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        exit;
+    }
+    header( 'Content-Type: text/plain' );
+    $out = '';
+    foreach ( Ai_Agent_DB::get_chats() as $chat ) {
+        $out .= '[' . $chat->timestamp . ' ' . $chat->visitor_id . "]\n";
+        $conv = json_decode( $chat->conversation, true );
+        foreach ( $conv as $c ) {
+            $out .= strtoupper( $c['role'] ) . ': ' . $c['content'] . "\n";
+        }
+        $out .= "\n";
+    }
+    echo $out;
+    exit;
+}
+if ( isset( $_GET['delete'] ) ) {
+    Ai_Agent_DB::delete_chat( (int) $_GET['delete'] );
+    wp_safe_redirect( remove_query_arg( [ 'delete' ] ) );
+    exit;
+}
+$chats = Ai_Agent_DB::get_chats();
+?>
+<p><a href="<?php echo esc_url( add_query_arg( 'export', 1 ) ); ?>" class="button"><?php _e( 'Export all as .txt', 'wp-ai-agent' ); ?></a></p>
+<table class="widefat">
+<thead><tr><th><?php _e( 'Date/Time', 'wp-ai-agent' ); ?></th><th><?php _e( 'Visitor ID', 'wp-ai-agent' ); ?></th><th><?php _e( 'Preview', 'wp-ai-agent' ); ?></th><th><?php _e( 'Action', 'wp-ai-agent' ); ?></th></tr></thead>
+<tbody>
+<?php foreach ( $chats as $chat ) : $conv = json_decode( $chat->conversation, true ); $preview = isset( $conv[0]['content'] ) ? $conv[0]['content'] : ''; ?>
+<tr>
+<td><?php echo esc_html( $chat->timestamp ); ?></td>
+<td><?php echo esc_html( $chat->visitor_id ); ?></td>
+<td><?php echo esc_html( wp_trim_words( $preview, 12 ) ); ?></td>
+<td><a href="<?php echo esc_url( add_query_arg( 'delete', $chat->id ) ); ?>" class="button"><?php _e( 'Delete', 'wp-ai-agent' ); ?></a></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -1,0 +1,49 @@
+<?php
+$settings = wp_ai_agent_get_settings();
+?>
+<form method="post" action="options.php">
+<?php settings_fields( 'wp_ai_agent' ); ?>
+<table class="form-table" role="presentation">
+<tr>
+<th scope="row"><label for="openai_key"><?php _e( 'OpenAI API Key', 'wp-ai-agent' ); ?></label></th>
+<td><input type="password" id="openai_key" name="wp_ai_agent_settings[openai_key]" value="" class="regular-text" /></td>
+</tr>
+<tr>
+<th scope="row"><label for="alt_key"><?php _e( 'Alternate API Key (Probex)', 'wp-ai-agent' ); ?></label></th>
+<td><input type="password" id="alt_key" name="wp_ai_agent_settings[alt_key]" value="" class="regular-text" /></td>
+</tr>
+<tr>
+<th scope="row"><label for="model"><?php _e( 'Model', 'wp-ai-agent' ); ?></label></th>
+<td><select id="model" name="wp_ai_agent_settings[model]">
+<option value="gpt-4o-mini" <?php selected( $settings['model'], 'gpt-4o-mini' ); ?>>gpt-4o-mini</option>
+<option value="deepseek-r1" <?php selected( $settings['model'], 'deepseek-r1' ); ?>>deepseek-r1</option>
+<option value="deepseek-v3" <?php selected( $settings['model'], 'deepseek-v3' ); ?>>deepseek-v3</option>
+</select></td>
+</tr>
+<tr>
+<th scope="row"><label for="quote_rules"><?php _e( 'Quote Rules (JSON)', 'wp-ai-agent' ); ?></label></th>
+<td><textarea id="quote_rules" name="wp_ai_agent_settings[quote_rules]" rows="5" class="large-text"><?php echo esc_textarea( $settings['quote_rules'] ); ?></textarea></td>
+</tr>
+<tr>
+<th scope="row"><?php _e( 'Sound Notifications', 'wp-ai-agent' ); ?></th>
+<td><label><input type="checkbox" name="wp_ai_agent_settings[sound]" value="1" <?php checked( ! empty( $settings['sound'] ) ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
+</tr>
+<tr>
+<th scope="row"><?php _e( 'Enter to send', 'wp-ai-agent' ); ?></th>
+<td><label><input type="checkbox" name="wp_ai_agent_settings[enter_send]" value="1" <?php checked( ! empty( $settings['enter_send'] ) ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
+</tr>
+<tr>
+<th scope="row"><?php _e( 'Debug Mode', 'wp-ai-agent' ); ?></th>
+<td><label><input type="checkbox" name="wp_ai_agent_settings[debug]" value="1" <?php checked( ! empty( $settings['debug'] ) ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
+</tr>
+<tr>
+<th scope="row"><label for="retention"><?php _e( 'Retention days', 'wp-ai-agent' ); ?></label></th>
+<td><input type="number" id="retention" name="wp_ai_agent_settings[retention]" value="<?php echo esc_attr( $settings['retention'] ?? 30 ); ?>" /></td>
+</tr>
+<tr>
+<th scope="row"><?php _e( 'Remove uploaded handbooks on uninstall', 'wp-ai-agent' ); ?></th>
+<td><label><input type="checkbox" name="wp_ai_agent_remove_uploads" value="1" <?php checked( get_option( 'wp_ai_agent_remove_uploads' ), 1 ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
+</tr>
+</table>
+<?php submit_button(); ?>
+</form>

--- a/wp-ai-agent/templates/admin-test-chat.php
+++ b/wp-ai-agent/templates/admin-test-chat.php
@@ -1,0 +1,10 @@
+<div id="wp-ai-agent-admin"></div>
+<p><button class="button" id="ai-agent-reset"><?php _e( 'Start New Chat', 'wp-ai-agent' ); ?></button></p>
+<script>
+(function(){
+    document.getElementById('ai-agent-reset').addEventListener('click', function(){
+        if(window.sessionStorage){sessionStorage.removeItem('wp_ai_agent_admin');}
+        document.querySelector('#wp-ai-agent-admin').innerHTML='';
+    });
+})();
+</script>

--- a/wp-ai-agent/templates/widget-template.php
+++ b/wp-ai-agent/templates/widget-template.php
@@ -1,0 +1,57 @@
+<?php
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+class Ai_Agent_Elementor_Widget extends Widget_Base {
+    public function get_name() {
+        return 'ai-agent-chat';
+    }
+
+    public function get_title() {
+        return __( 'AI Agent Chat', 'wp-ai-agent' );
+    }
+
+    public function get_icon() {
+        return 'eicon-chat';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    protected function _register_controls() {
+        $this->start_controls_section( 'section_content', [
+            'label' => __( 'Settings', 'wp-ai-agent' ),
+        ] );
+        $this->add_control( 'show_button', [
+            'label' => __( 'Show Floating Button', 'wp-ai-agent' ),
+            'type' => Controls_Manager::SWITCHER,
+            'default' => 'yes',
+        ] );
+        $this->add_control( 'position', [
+            'label' => __( 'Position', 'wp-ai-agent' ),
+            'type' => Controls_Manager::SELECT,
+            'default' => 'right',
+            'options' => [ 'right' => __( 'Bottom Right', 'wp-ai-agent' ), 'left' => __( 'Bottom Left', 'wp-ai-agent' ) ],
+        ] );
+        $this->add_control( 'label', [
+            'label' => __( 'Label', 'wp-ai-agent' ),
+            'type' => Controls_Manager::TEXT,
+            'default' => __( 'Chat', 'wp-ai-agent' ),
+        ] );
+        $this->add_control( 'color', [
+            'label' => __( 'Color', 'wp-ai-agent' ),
+            'type' => Controls_Manager::COLOR,
+            'default' => '#25D366',
+        ] );
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        if ( 'yes' !== $settings['show_button'] ) {
+            return;
+        }
+        echo '<div class="ai-agent-el" data-position="' . esc_attr( $settings['position'] ) . '" data-color="' . esc_attr( $settings['color'] ) . '">' . esc_html( $settings['label'] ) . '</div>';
+    }
+}

--- a/wp-ai-agent/uninstall.php
+++ b/wp-ai-agent/uninstall.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Uninstall script for AI Agent plugin.
+ */
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-ai-agent-db.php';
+require_once __DIR__ . '/includes/helpers.php';
+
+$remove = (int) get_option( 'wp_ai_agent_remove_uploads', 0 );
+if ( $remove ) {
+    $dir = wp_get_upload_dir();
+    $folder = trailingslashit( $dir['basedir'] ) . 'ai-agent-handbooks/';
+    if ( is_dir( $folder ) ) {
+        foreach ( glob( $folder . '*', GLOB_NOSORT ) as $file ) {
+            @unlink( $file );
+        }
+        @rmdir( $folder );
+    }
+}
+
+Ai_Agent_DB::drop_tables();
+delete_option( 'wp_ai_agent_settings' );
+delete_option( 'wp_ai_agent_remove_uploads' );
+Ai_Agent_DB::clear_cron();

--- a/wp-ai-agent/wp-ai-agent.php
+++ b/wp-ai-agent/wp-ai-agent.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Plugin Name: AI Agent (Chat + Quotes)
+ * Description: WhatsApp-style AI chat with quote generation.
+ * Version: 1.0.0
+ * Author: AI Agent Bot
+ * Text Domain: wp-ai-agent
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Define constants.
+define( 'WP_AI_AGENT_VERSION', '1.0.0' );
+define( 'WP_AI_AGENT_DIR', plugin_dir_path( __FILE__ ) );
+define( 'WP_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
+
+require_once WP_AI_AGENT_DIR . 'includes/helpers.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-encryption.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-db.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-admin.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-ajax.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-handbooks.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-elementor.php';
+require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-render.php';
+
+/**
+ * Activation hook.
+ */
+function wp_ai_agent_activate() {
+    Ai_Agent_DB::create_tables();
+    Ai_Agent_DB::schedule_cron();
+}
+register_activation_hook( __FILE__, 'wp_ai_agent_activate' );
+
+/**
+ * Deactivation hook.
+ */
+function wp_ai_agent_deactivate() {
+    Ai_Agent_DB::clear_cron();
+}
+register_deactivation_hook( __FILE__, 'wp_ai_agent_deactivate' );
+
+// Initialize plugin pieces.
+add_action( 'plugins_loaded', function() {
+    load_plugin_textdomain( 'wp-ai-agent', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    new Ai_Agent_Admin();
+    new Ai_Agent_AJAX();
+    new Ai_Agent_Handbooks();
+    new Ai_Agent_Elementor();
+    new Ai_Agent_Render();
+} );


### PR DESCRIPTION
## Summary
- add initial AI Agent plugin with WhatsApp-style chat and admin pages
- include handbook uploads, chat history, and Elementor widget

## Testing
- `find wp-ai-agent -name "*.php" -print0 | xargs -0 -n1 php -l`
- `wp --allow-root i18n make-pot wp-ai-agent wp-ai-agent/languages/wp-ai-agent.pot`

------
https://chatgpt.com/codex/tasks/task_e_6899c88260e88320b90068a779f74bac