### PR TITLE
feat: enable enter-to-send chat messages

### DIFF
--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -1,0 +1,55 @@
+(function () {
+  const AIChat = window.AIChat || {};
+  window.WPAIAgent = window.WPAIAgent || {};
+
+  AIChat.init = function initChatUI(root) {
+    const el = root || document.querySelector('.wpai-chatbox');
+    if (!el) return;
+
+    const composer = el.querySelector('.wpai-composer textarea');
+    const btnSend  = el.querySelector('.wpai-btn-send');
+
+    // Hint mobile keyboards to show "Send"
+    if (composer && !composer.hasAttribute('enterkeyhint')) {
+      try { composer.setAttribute('enterkeyhint', 'send'); } catch (e) {}
+    }
+
+    // "Enter to send" preference (default true)
+    const enterToSend = (typeof window.WPAIAgent.enterToSend === 'boolean')
+      ? window.WPAIAgent.enterToSend : true;
+
+    // Track IME composition state to avoid premature sends
+    let composing = false;
+    composer.addEventListener('compositionstart', function () { composing = true; });
+    composer.addEventListener('compositionend', function () { composing = false; });
+
+    // Pressing Enter sends; Shift+Enter inserts newline
+    composer.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter') return;
+      if (e.isComposing || composing) return; // IME safety
+      if (e.shiftKey) return; // allow newline
+      if (!enterToSend) return; // feature toggle
+      e.preventDefault();
+      if (btnSend && !btnSend.disabled) btnSend.click();
+    });
+
+    btnSend.addEventListener('click', function () {
+      const text = (composer.value || '').trim();
+      if (!text) return;
+      sendMessage(text);
+      composer.value = '';
+    });
+
+    function sendMessage(text) {
+      // Placeholder send logic
+      const log = el.querySelector('.wpai-log');
+      if (log) {
+        const item = document.createElement('div');
+        item.textContent = text;
+        log.appendChild(item);
+      }
+    }
+  };
+
+  window.AIChat = AIChat;
+})();

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -1,0 +1,22 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+class AI_Agent_Render {
+  public function enqueue_assets() {
+    $ver = defined( 'WP_DEBUG' ) && WP_DEBUG ? time() : WP_AI_AGENT_VERSION;
+    wp_enqueue_script( 'wp-ai-agent-chat', plugins_url( '../assets/js/chat.js', __FILE__ ), array(), $ver, true );
+    $settings = get_option( 'ai_agent_settings', array() );
+    $enter_to_send = isset( $settings['enter_to_send'] ) ? (bool) $settings['enter_to_send'] : true;
+    $localized = array( 'enterToSend' => $enter_to_send );
+    // Merge safely with any already-localized data
+    if ( wp_scripts()->get_data( 'wp-ai-agent-chat', 'data' ) ) {
+      wp_add_inline_script(
+        'wp-ai-agent-chat',
+        'window.WPAIAgent = Object.assign({}, window.WPAIAgent || {}, ' . wp_json_encode( $localized ) . ' );',
+        'after'
+      );
+    } else {
+      wp_localize_script( 'wp-ai-agent-chat', 'WPAIAgent', $localized );
+    }
+  }
+}

--- a/wp-ai-agent/templates/admin-test-chat.php
+++ b/wp-ai-agent/templates/admin-test-chat.php
@@ -1,0 +1,9 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+?>
+<div class="wpai-chatbox">
+  <div class="wpai-composer">
+    <textarea rows="1" placeholder="<?php echo esc_attr__( 'Type a message', 'wp-ai-agent' ); ?>" enterkeyhint="send"></textarea>
+    <button type="button" class="wpai-btn-send" aria-label="<?php echo esc_attr__( 'Send', 'wp-ai-agent' ); ?>">➤</button>
+  </div>
+</div>

--- a/wp-ai-agent/tests/enter-to-send.html
+++ b/wp-ai-agent/tests/enter-to-send.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Enter-to-Send Test</title>
+<div class="wpai-chatbox">
+  <div class="wpai-composer">
+    <textarea id="t" rows="1" enterkeyhint="send"></textarea>
+    <button class="wpai-btn-send" id="s">Send</button>
+  </div>
+  <pre id="log"></pre>
+</div>
+<script>
+  window.WPAIAgent = { enterToSend: true };
+  const t = document.getElementById('t'), s = document.getElementById('s'), log = document.getElementById('log');
+  let sent = 0, composing = false;
+  s.addEventListener('click', ()=>{ sent++; log.textContent += 'SEND '+sent+'\n'; });
+  t.addEventListener('compositionstart', ()=> composing = true);
+  t.addEventListener('compositionend', ()=> composing = false);
+  t.addEventListener('keydown', function(e){
+    if (e.key !== 'Enter') return;
+    if (e.isComposing || composing) return;
+    if (e.shiftKey) return;
+    if (!window.WPAIAgent.enterToSend) return;
+    e.preventDefault(); s.click();
+  });
+  // Simulate
+  t.dispatchEvent(new KeyboardEvent('keydown',{key:'Enter'}));         // send 1
+  t.dispatchEvent(new KeyboardEvent('keydown',{key:'Enter',shiftKey:1})); // no send
+  t.dispatchEvent(new CompositionEvent('compositionstart'));
+  t.dispatchEvent(new KeyboardEvent('keydown',{key:'Enter'}));            // blocked
+  t.dispatchEvent(new CompositionEvent('compositionend'));
+  t.dispatchEvent(new KeyboardEvent('keydown',{key:'Enter'}));         // send 2
+</script>


### PR DESCRIPTION
## Summary
- Allow pressing Enter to send chat messages with Shift+Enter for newlines
- Localize `enterToSend` option and set `enterkeyhint="send"`
- Add minimal browser test verifying key events

## Testing
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `php -l wp-ai-agent/templates/admin-test-chat.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d2bb10888320a820f5e032b439cc