### PR TITLE
feat(chat): typing indicator with animated dots; per-session Australian agent name selection

### DIFF
--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -9,3 +9,12 @@
 .ai-agent-msg.bot { background:#fff; align-self:flex-start; }
 .ai-agent-msg { padding:6px 8px; margin:4px; border-radius:6px; max-width:80%; }
 @media (max-width:767px){ .ai-agent-window{ width:100%; height:100vh; border-radius:0; right:0; bottom:0; }}
+
+.wpai-typing { display:flex; align-items:center; gap:8px; padding:8px 12px; opacity:0; height:0; overflow:hidden; transition:opacity .2s ease,height .2s ease; }
+.wpai-typing.active { opacity:1; height:auto; }
+.wpai-typing__label { font-size:0.9rem; }
+.wpai-dots { display:inline-flex; gap:4px; }
+.wpai-dot { opacity:0.2; animation: wpai-blink 1s infinite; }
+.wpai-dot:nth-child(2){ animation-delay:.2s; }
+.wpai-dot:nth-child(3){ animation-delay:.4s; }
+@keyframes wpai-blink{ 0%,20%{opacity:.2} 50%{opacity:1} 100%{opacity:.2} }

--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -4,15 +4,27 @@
     var root=document.getElementById('wp-ai-agent-root');
     if(!root){root=document.getElementById('wp-ai-agent-admin');}
     if(!root)return;
+    var names=(window.wpaiAgentNames&&Array.isArray(window.wpaiAgentNames)&&window.wpaiAgentNames.length)?window.wpaiAgentNames:["Jack Wilson","Olivia Nguyen","Liam O'Connor","Chloe Smith","Noah Patel"];
+    var idx=sessionStorage.getItem('wpaiAgentNameIndex');
+    if(idx===null){idx=Math.floor(Math.random()*names.length);sessionStorage.setItem('wpaiAgentNameIndex',String(idx));}else{idx=Number(idx)%names.length;}
+    var agentName=names[idx];
     var btn=document.createElement('div');btn.className='ai-agent-button';btn.innerHTML='<svg width="24" height="24"><use href="'+wpAiAgent.assets+'/icons/icons.svg#chat"/></svg>';
-    var win=document.createElement('div');win.className='ai-agent-window';win.innerHTML='<div class="ai-agent-header">AI Agent</div><div class="ai-agent-messages"></div><div class="ai-agent-input"><textarea rows="2"></textarea><button>Send</button></div>';
+    var win=document.createElement('div');win.className='ai-agent-window';win.innerHTML='<div class="ai-agent-header"></div><div class="ai-agent-messages"></div><div class="ai-agent-input"><textarea rows="2"></textarea><button>Send</button></div>';
     root.appendChild(btn);root.appendChild(win);
+    win.querySelector('.ai-agent-header').textContent=agentName;
+    var messages=win.querySelector('.ai-agent-messages');
+    var typing=messages.querySelector('.wpai-typing');
+    if(!typing){typing=document.createElement('div');typing.className='wpai-typing';typing.setAttribute('role','status');typing.setAttribute('aria-live','polite');typing.innerHTML='<span class="wpai-typing__label"></span><span class="wpai-dots"><span class="wpai-dot">•</span><span class="wpai-dot">•</span><span class="wpai-dot">•</span></span>';messages.appendChild(typing);}
+    var labelEl=typing.querySelector('.wpai-typing__label');
     var open=false;btn.addEventListener('click',function(){win.style.display=open?'none':'flex';open=!open;});
     var ta=win.querySelector('textarea');var send=win.querySelector('button');
-    function addMsg(role,text){var m=document.createElement('div');m.className='ai-agent-msg '+role;m.textContent=text;win.querySelector('.ai-agent-messages').appendChild(m);win.querySelector('.ai-agent-messages').scrollTop=999999;}
-    function renderQuote(q){var card=document.createElement('pre');card.className='ai-agent-quote';card.textContent=JSON.stringify(q,null,2);win.querySelector('.ai-agent-messages').appendChild(card);}
+    function scrollToBottom(){messages.scrollTop=messages.scrollHeight;}
+    function addMsg(role,text){var m=document.createElement('div');m.className='ai-agent-msg '+role;m.textContent=text;messages.insertBefore(m,typing);scrollToBottom();}
+    function renderQuote(q){var card=document.createElement('pre');card.className='ai-agent-quote';card.textContent=JSON.stringify(q,null,2);messages.insertBefore(card,typing);}
+    function showTyping(){labelEl.textContent=agentName+' is typing';typing.classList.add('active');scrollToBottom();}
+    function hideTyping(){typing.classList.remove('active');}
     send.addEventListener('click',function(){var msg=ta.value.trim();if(!msg)return;ta.value='';addMsg('user',msg);sendMsg(msg);});
     if(wpAiAgent.enterSend){ta.addEventListener('keydown',function(e){if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();send.click();}});}
     var convo=[];
-    function sendMsg(msg){var data=new FormData();data.append('action','ai_agent_chat');data.append('visitor',vid);data.append('message',msg);data.append('conversation',JSON.stringify(convo));fetch(wpAiAgent.ajax,{method:'POST',body:data}).then(function(res){var reader=res.body.getReader();var decoder=new TextDecoder();var out='';function read(){reader.read().then(function(r){if(r.done){convo.push({role:'user',content:msg});convo.push({role:'assistant',content:out});try{var q=JSON.parse(out);if(q.items){renderQuote(q);out='';}}catch(e){}addMsg('bot',out);return;}var str=decoder.decode(r.value);str.split('\n').forEach(function(line){if(line.startsWith('data:')){var payload=line.replace('data:','').trim();if(payload==='[DONE]'){return;}try{var j=JSON.parse(payload);if(j.choices&&j.choices[0].delta&&j.choices[0].delta.content){out+=j.choices[0].delta.content;}}catch(e){}}});read();});}read();});}
+    function sendMsg(msg){var data=new FormData();data.append('action','ai_agent_chat');data.append('visitor',vid);data.append('message',msg);data.append('conversation',JSON.stringify(convo));showTyping();fetch(wpAiAgent.ajax,{method:'POST',body:data}).then(function(res){if(!res.body||!res.body.getReader){return res.text().then(function(out){convo.push({role:'user',content:msg});convo.push({role:'assistant',content:out});try{var q=JSON.parse(out);if(q.items){renderQuote(q);out='';}}catch(e){}addMsg('bot',out);hideTyping();});}var reader=res.body.getReader();var decoder=new TextDecoder();var out='';function read(){reader.read().then(function(r){if(r.done){convo.push({role:'user',content:msg});convo.push({role:'assistant',content:out});try{var q=JSON.parse(out);if(q.items){renderQuote(q);out='';}}catch(e){}addMsg('bot',out);hideTyping();return;}var str=decoder.decode(r.value);str.split('\n').forEach(function(line){if(line.startsWith('data:')){var payload=line.replace('data:','').trim();if(payload==='[DONE]'){return;}try{var j=JSON.parse(payload);if(j.choices&&j.choices[0].delta&&j.choices[0].delta.content){out+=j.choices[0].delta.content;}}catch(e){}}});read();}).catch(function(){hideTyping();});}read();}).catch(function(){hideTyping();});}
 })(jQuery);

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -21,6 +21,11 @@ class Ai_Agent_Render {
             'sound'     => ! empty( $settings['sound'] ),
             'debug'     => ! empty( $settings['debug'] ),
         ] );
+        wp_localize_script(
+            'wp-ai-agent',
+            'wpaiAgentNames',
+            [ 'Jack Wilson', 'Olivia Nguyen', "Liam O'Connor", 'Chloe Smith', 'Noah Patel' ]
+        );
         wp_enqueue_style( 'wp-ai-agent' );
         wp_enqueue_script( 'wp-ai-agent' );
     }


### PR DESCRIPTION
## Summary
- localize list of five Australian names and pick one per browser session
- add a reusable typing indicator node and toggle it during fetch/stream responses
- style the typing indicator with animated dots and ARIA-friendly status messaging

## Testing
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899e2597de48320bfd53dd117ff3165