### PR TITLE
Improve assistant stream rendering

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -1,3 +1,5 @@
+import { sendChatRequest } from './chat-transport.js';
+
 (function(){
     const config = window.WPAI_CONFIG || {};
     const selectors = config.selectors || {};
@@ -105,55 +107,50 @@
             scrollBottom();
         }
 
-        function sendMsg(msg){
+        async function sendMsg(msg){
             const typingEl = showTyping();
-            const data = new FormData();
-            data.append('action', 'ai_agent_chat');
-            data.append('visitor', visitor);
-            data.append('message', msg);
-            data.append('conversation', JSON.stringify(convo));
-
-            fetch(config.ajax, {method:'POST', body:data}).then(function(res){
-                const ct = res.headers.get('Content-Type') || '';
-                if(ct.indexOf('text/event-stream') !== -1 && res.body){
-                    const reader = res.body.getReader();
-                    const decoder = new TextDecoder();
-                    let out = '';
-                    function read(){
-                        reader.read().then(function(r){
-                            if(r.done){
-                                convo.push({role:'user',content:msg});
-                                convo.push({role:'assistant',content:out});
-                                finishTyping(typingEl, out);
-                                return;
-                            }
-                            const str = decoder.decode(r.value);
-                            str.split('\n').forEach(function(line){
-                                if(line.startsWith('data:')){
-                                    const payload = line.replace('data:','').trim();
-                                    if(payload === '[DONE]'){ return; }
-                                    try{
-                                        const j = JSON.parse(payload);
-                                        const d = j.choices && j.choices[0] && j.choices[0].delta && j.choices[0].delta.content;
-                                        if(d){ out += d; }
-                                    }catch(e){}
-                                }
-                            });
+            let textNode = null;
+            send.disabled = true;
+            ta.disabled = true;
+            try {
+                await sendChatRequest({
+                    url: config.ajax + '?action=ai_agent_chat',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: {
+                        visitor,
+                        message: msg,
+                        conversation: convo
+                    },
+                    onToken(token){
+                        if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+out;
-                            scrollBottom();
-                            read();
-                        });
-                    }
-                    read();
-                } else {
-                    res.text().then(function(out){
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="ai-agent-text"></span>';
+                            textNode = typingEl.querySelector('.ai-agent-text');
+                        }
+                        textNode.textContent += token;
+                        scrollBottom();
+                    },
+                    onDone(full){
+                        if(textNode){
+                            finishTyping(typingEl, textNode.textContent);
+                        } else {
+                            typingEl.remove();
+                        }
                         convo.push({role:'user',content:msg});
-                        convo.push({role:'assistant',content:out});
-                        finishTyping(typingEl, out);
-                    });
-                }
-            }).catch(function(){ typingEl.remove(); });
+                        convo.push({role:'assistant',content:full});
+                    }
+                });
+            } catch (err) {
+                typingEl.remove();
+                const m = document.createElement('div');
+                m.className = 'ai-agent-msg bot';
+                m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+(err.message || 'Error');
+                list.appendChild(m);
+                scrollBottom();
+            } finally {
+                send.disabled = false;
+                ta.disabled = false;
+            }
         }
 
         send.addEventListener('click', function(){

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -1,3 +1,5 @@
+import { sendChatRequest } from './chat-transport.js';
+
 (function(){
     const config = window.WPAI_CONFIG || {};
     const selectors = config.selectors || {};
@@ -105,55 +107,50 @@
             scrollBottom();
         }
 
-        function sendMsg(msg){
+        async function sendMsg(msg){
             const typingEl = showTyping();
-            const data = new FormData();
-            data.append('action', 'ai_agent_chat');
-            data.append('visitor', visitor);
-            data.append('message', msg);
-            data.append('conversation', JSON.stringify(convo));
-
-            fetch(config.ajax, {method:'POST', body:data}).then(function(res){
-                const ct = res.headers.get('Content-Type') || '';
-                if(ct.indexOf('text/event-stream') !== -1 && res.body){
-                    const reader = res.body.getReader();
-                    const decoder = new TextDecoder();
-                    let out = '';
-                    function read(){
-                        reader.read().then(function(r){
-                            if(r.done){
-                                convo.push({role:'user',content:msg});
-                                convo.push({role:'assistant',content:out});
-                                finishTyping(typingEl, out);
-                                return;
-                            }
-                            const str = decoder.decode(r.value);
-                            str.split('\n').forEach(function(line){
-                                if(line.startsWith('data:')){
-                                    const payload = line.replace('data:','').trim();
-                                    if(payload === '[DONE]'){ return; }
-                                    try{
-                                        const j = JSON.parse(payload);
-                                        const d = j.choices && j.choices[0] && j.choices[0].delta && j.choices[0].delta.content;
-                                        if(d){ out += d; }
-                                    }catch(e){}
-                                }
-                            });
+            let textNode = null;
+            send.disabled = true;
+            ta.disabled = true;
+            try {
+                await sendChatRequest({
+                    url: config.ajax + '?action=ai_agent_chat',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: {
+                        visitor,
+                        message: msg,
+                        conversation: convo
+                    },
+                    onToken(token){
+                        if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+out;
-                            scrollBottom();
-                            read();
-                        });
-                    }
-                    read();
-                } else {
-                    res.text().then(function(out){
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="ai-agent-text"></span>';
+                            textNode = typingEl.querySelector('.ai-agent-text');
+                        }
+                        textNode.textContent += token;
+                        scrollBottom();
+                    },
+                    onDone(full){
+                        if(textNode){
+                            finishTyping(typingEl, textNode.textContent);
+                        } else {
+                            typingEl.remove();
+                        }
                         convo.push({role:'user',content:msg});
-                        convo.push({role:'assistant',content:out});
-                        finishTyping(typingEl, out);
-                    });
-                }
-            }).catch(function(){ typingEl.remove(); });
+                        convo.push({role:'assistant',content:full});
+                    }
+                });
+            } catch (err) {
+                typingEl.remove();
+                const m = document.createElement('div');
+                m.className = 'ai-agent-msg bot';
+                m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+(err.message || 'Error');
+                list.appendChild(m);
+                scrollBottom();
+            } finally {
+                send.disabled = false;
+                ta.disabled = false;
+            }
         }
 
         send.addEventListener('click', function(){

--- a/wp-ai-agent/assets/js/chat-transport.js
+++ b/wp-ai-agent/assets/js/chat-transport.js
@@ -1,0 +1,54 @@
+export async function sendChatRequest({url, headers = {}, body = {}, streamPreferred = true, onToken, onDone}) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort('timeout'), 90_000);
+  let full = '';
+  try {
+    const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body), signal: ctrl.signal });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const ctype = (res.headers.get('content-type') || '').toLowerCase();
+    if (streamPreferred && (res.body && (ctype.includes('text/event-stream') || ctype.includes('application/json')))) {
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let done, value, buf = '';
+      while (true) {
+        ({done, value} = await reader.read());
+        if (done) break;
+        buf += decoder.decode(value, {stream:true});
+        let idx;
+        while ((idx = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, idx).trim();
+          buf = buf.slice(idx+1);
+          if (!line) continue;
+          const dataLine = line.startsWith('data:') ? line.slice(5).trim() : line;
+          if (dataLine === '[DONE]') { onDone?.(full); return full; }
+          try {
+            const obj = JSON.parse(dataLine);
+            const choice = obj.choices && obj.choices[0];
+            const delta = choice && (choice.delta?.content ?? choice.message?.content ?? '');
+            if (delta) {
+              full += delta;
+              onToken?.(delta);
+            }
+          } catch {}
+        }
+      }
+      try {
+        const obj = JSON.parse(buf);
+        const content = obj?.choices?.[0]?.message?.content ?? '';
+        if (content) { full += content; onToken?.(content); }
+      } catch {}
+      onDone?.(full);
+      return full;
+    }
+    const json = await res.json();
+    const content = json?.choices?.[0]?.message?.content ?? json?.message?.content ?? '';
+    if (content) {
+      full += content;
+      onToken?.(content);
+    }
+    onDone?.(full);
+    return full;
+  } finally {
+    clearTimeout(t);
+  }
+}

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -20,9 +20,10 @@ class Ai_Agent_AJAX {
 
     public function chat() {
         nocache_headers();
-        $visitor = sanitize_text_field( $_POST['visitor'] ?? '' );
-        $message = sanitize_textarea_field( $_POST['message'] ?? '' );
-        $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+        $input = json_decode( file_get_contents( 'php://input' ), true );
+        $visitor = sanitize_text_field( $_POST['visitor'] ?? ( $input['visitor'] ?? '' ) );
+        $message = sanitize_textarea_field( $_POST['message'] ?? ( $input['message'] ?? '' ) );
+        $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : ( $input['conversation'] ?? [] );
         $this->rate_limit( $visitor );
 
         $settings = wp_ai_agent_get_settings();

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -37,6 +37,7 @@ class Ai_Agent_Render {
         wp_enqueue_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
 
         wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [], WP_AI_AGENT_VERSION, true );
+        wp_script_add_data( 'wp-ai-agent-frontend', 'type', 'module' );
         wp_localize_script( 'wp-ai-agent-frontend', 'WPAI_CONFIG', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-frontend' );
     }
@@ -49,6 +50,7 @@ class Ai_Agent_Render {
         wp_enqueue_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
 
         wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [], WP_AI_AGENT_VERSION, true );
+        wp_script_add_data( 'wp-ai-agent-admin', 'type', 'module' );
         wp_localize_script( 'wp-ai-agent-admin', 'WPAI_CONFIG', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-admin' );
     }


### PR DESCRIPTION
## Summary
- add shared `sendChatRequest` transport to process streaming or JSON responses
- render assistant message once and append tokens as they arrive in admin and front-end chats
- accept JSON payloads and load scripts as ES modules

## Testing
- `node --check wp-ai-agent/assets/js/chat-transport.js`
- `node --check wp-ai-agent/assets/js/chat-frontend.js`
- `node --check wp-ai-agent/assets/js/chat-admin.js`
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_6899ea5b7bbc8320b281eb05872a4bff