### PR TITLE
Ensure assistant stream rendering

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -92,68 +92,53 @@
             return m;
         }
 
-        function finishTyping(el, text){
-            try{
-                const q = JSON.parse(text);
-                if(q && q.items){
-                    renderQuote(q);
-                    text = '';
-                }
-            }catch(e){}
-            el.classList.remove('typing');
-            el.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+text;
-            scrollBottom();
-        }
-
-        function sendMsg(msg){
+        async function sendMsg(msg){
             const typingEl = showTyping();
-            const data = new FormData();
-            data.append('action', 'ai_agent_chat');
-            data.append('visitor', visitor);
-            data.append('message', msg);
-            data.append('conversation', JSON.stringify(convo));
-
-            fetch(config.ajax, {method:'POST', body:data}).then(function(res){
-                const ct = res.headers.get('Content-Type') || '';
-                if(ct.indexOf('text/event-stream') !== -1 && res.body){
-                    const reader = res.body.getReader();
-                    const decoder = new TextDecoder();
-                    let out = '';
-                    function read(){
-                        reader.read().then(function(r){
-                            if(r.done){
-                                convo.push({role:'user',content:msg});
-                                convo.push({role:'assistant',content:out});
-                                finishTyping(typingEl, out);
-                                return;
-                            }
-                            const str = decoder.decode(r.value);
-                            str.split('\n').forEach(function(line){
-                                if(line.startsWith('data:')){
-                                    const payload = line.replace('data:','').trim();
-                                    if(payload === '[DONE]'){ return; }
-                                    try{
-                                        const j = JSON.parse(payload);
-                                        const d = j.choices && j.choices[0] && j.choices[0].delta && j.choices[0].delta.content;
-                                        if(d){ out += d; }
-                                    }catch(e){}
-                                }
-                            });
+            ta.disabled = true;
+            send.disabled = true;
+            let textNode;
+            try{
+                const full = await window.WPAI.sendChatRequest({
+                    url: config.ajax + '?action=ai_agent_chat',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: { visitor: visitor, message: msg, conversation: convo },
+                    onToken: function(tok){
+                        if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+out;
-                            scrollBottom();
-                            read();
-                        });
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
+                            textNode = document.createTextNode(tok);
+                            typingEl.appendChild(textNode);
+                        } else {
+                            textNode.textContent += tok;
+                        }
+                        scrollBottom();
                     }
-                    read();
-                } else {
-                    res.text().then(function(out){
-                        convo.push({role:'user',content:msg});
-                        convo.push({role:'assistant',content:out});
-                        finishTyping(typingEl, out);
-                    });
+                });
+                convo.push({role:'user',content:msg});
+                convo.push({role:'assistant',content:full});
+                if(!textNode){
+                    typingEl.classList.remove('typing');
+                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
                 }
-            }).catch(function(){ typingEl.remove(); });
+                try{
+                    const q = JSON.parse(full);
+                    if(q && q.items){
+                        renderQuote(q);
+                        if(textNode){ textNode.textContent = ''; }
+                    }
+                }catch(e){}
+            } catch(e){
+                typingEl.remove();
+                const err = document.createElement('div');
+                err.className = 'ai-agent-msg bot';
+                err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
+                list.appendChild(err);
+                scrollBottom();
+            } finally {
+                ta.disabled = false;
+                send.disabled = false;
+                scrollBottom();
+            }
         }
 
         send.addEventListener('click', function(){

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -92,68 +92,53 @@
             return m;
         }
 
-        function finishTyping(el, text){
-            try{
-                const q = JSON.parse(text);
-                if(q && q.items){
-                    renderQuote(q);
-                    text = '';
-                }
-            }catch(e){}
-            el.classList.remove('typing');
-            el.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+text;
-            scrollBottom();
-        }
-
-        function sendMsg(msg){
+        async function sendMsg(msg){
             const typingEl = showTyping();
-            const data = new FormData();
-            data.append('action', 'ai_agent_chat');
-            data.append('visitor', visitor);
-            data.append('message', msg);
-            data.append('conversation', JSON.stringify(convo));
-
-            fetch(config.ajax, {method:'POST', body:data}).then(function(res){
-                const ct = res.headers.get('Content-Type') || '';
-                if(ct.indexOf('text/event-stream') !== -1 && res.body){
-                    const reader = res.body.getReader();
-                    const decoder = new TextDecoder();
-                    let out = '';
-                    function read(){
-                        reader.read().then(function(r){
-                            if(r.done){
-                                convo.push({role:'user',content:msg});
-                                convo.push({role:'assistant',content:out});
-                                finishTyping(typingEl, out);
-                                return;
-                            }
-                            const str = decoder.decode(r.value);
-                            str.split('\n').forEach(function(line){
-                                if(line.startsWith('data:')){
-                                    const payload = line.replace('data:','').trim();
-                                    if(payload === '[DONE]'){ return; }
-                                    try{
-                                        const j = JSON.parse(payload);
-                                        const d = j.choices && j.choices[0] && j.choices[0].delta && j.choices[0].delta.content;
-                                        if(d){ out += d; }
-                                    }catch(e){}
-                                }
-                            });
+            ta.disabled = true;
+            send.disabled = true;
+            let textNode;
+            try{
+                const full = await window.WPAI.sendChatRequest({
+                    url: config.ajax + '?action=ai_agent_chat',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: { visitor: visitor, message: msg, conversation: convo },
+                    onToken: function(tok){
+                        if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+out;
-                            scrollBottom();
-                            read();
-                        });
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
+                            textNode = document.createTextNode(tok);
+                            typingEl.appendChild(textNode);
+                        } else {
+                            textNode.textContent += tok;
+                        }
+                        scrollBottom();
                     }
-                    read();
-                } else {
-                    res.text().then(function(out){
-                        convo.push({role:'user',content:msg});
-                        convo.push({role:'assistant',content:out});
-                        finishTyping(typingEl, out);
-                    });
+                });
+                convo.push({role:'user',content:msg});
+                convo.push({role:'assistant',content:full});
+                if(!textNode){
+                    typingEl.classList.remove('typing');
+                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
                 }
-            }).catch(function(){ typingEl.remove(); });
+                try{
+                    const q = JSON.parse(full);
+                    if(q && q.items){
+                        renderQuote(q);
+                        if(textNode){ textNode.textContent = ''; }
+                    }
+                }catch(e){}
+            } catch(e){
+                typingEl.remove();
+                const err = document.createElement('div');
+                err.className = 'ai-agent-msg bot';
+                err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
+                list.appendChild(err);
+                scrollBottom();
+            } finally {
+                ta.disabled = false;
+                send.disabled = false;
+                scrollBottom();
+            }
         }
 
         send.addEventListener('click', function(){

--- a/wp-ai-agent/assets/js/chat-transport.js
+++ b/wp-ai-agent/assets/js/chat-transport.js
@@ -1,0 +1,58 @@
+(function(){
+  async function sendChatRequest({url, headers={}, body, streamPreferred=true, onToken, onDone}) {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort('timeout'), 90_000);
+    let full = '';
+    try {
+      const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body), signal: ctrl.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const ctype = (res.headers.get('content-type') || '').toLowerCase();
+      if (streamPreferred && (res.body && (ctype.includes('text/event-stream') || ctype.includes('application/json')))) {
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let done, value, buf = '';
+        while (true) {
+          ({done, value} = await reader.read());
+          if (done) break;
+          buf += decoder.decode(value, {stream:true});
+          let idx;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx+1);
+            if (!line) continue;
+            const dataLine = line.startsWith('data:') ? line.slice(5).trim() : line;
+            if (dataLine === '[DONE]') { onDone && onDone(full); return full; }
+            try {
+              const obj = JSON.parse(dataLine);
+              const choice = obj.choices && obj.choices[0];
+              const delta = choice && (choice.delta?.content ?? choice.message?.content ?? '');
+              if (delta) {
+                full += delta;
+                onToken && onToken(delta);
+              }
+            } catch {}
+          }
+        }
+        try {
+          const obj = JSON.parse(buf);
+          const content = obj?.choices?.[0]?.message?.content ?? '';
+          if (content) { full += content; onToken && onToken(content); }
+        } catch {}
+        onDone && onDone(full);
+        return full;
+      }
+      const json = await res.json();
+      const content = json?.choices?.[0]?.message?.content ?? json?.message?.content ?? '';
+      if (content) {
+        full += content;
+        onToken && onToken(content);
+      }
+      onDone && onDone(full);
+      return full;
+    } finally {
+      clearTimeout(t);
+    }
+  }
+  window.WPAI = window.WPAI || {};
+  window.WPAI.sendChatRequest = sendChatRequest;
+})();

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -20,9 +20,17 @@ class Ai_Agent_AJAX {
 
     public function chat() {
         nocache_headers();
-        $visitor = sanitize_text_field( $_POST['visitor'] ?? '' );
-        $message = sanitize_textarea_field( $_POST['message'] ?? '' );
-        $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+        $input = file_get_contents( 'php://input' );
+        $json  = json_decode( $input, true );
+        if ( is_array( $json ) ) {
+            $visitor      = sanitize_text_field( $json['visitor'] ?? '' );
+            $message      = sanitize_textarea_field( $json['message'] ?? '' );
+            $conversation = isset( $json['conversation'] ) ? (array) $json['conversation'] : [];
+        } else {
+            $visitor      = sanitize_text_field( $_POST['visitor'] ?? '' );
+            $message      = sanitize_textarea_field( $_POST['message'] ?? '' );
+            $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+        }
         $this->rate_limit( $visitor );
 
         $settings = wp_ai_agent_get_settings();

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -36,7 +36,8 @@ class Ai_Agent_Render {
     public function assets() {
         wp_enqueue_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
 
-        wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [], WP_AI_AGENT_VERSION, true );
+        wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
+        wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
         wp_localize_script( 'wp-ai-agent-frontend', 'WPAI_CONFIG', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-frontend' );
     }
@@ -48,7 +49,8 @@ class Ai_Agent_Render {
 
         wp_enqueue_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
 
-        wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [], WP_AI_AGENT_VERSION, true );
+        wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
+        wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
         wp_localize_script( 'wp-ai-agent-admin', 'WPAI_CONFIG', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-admin' );
     }


### PR DESCRIPTION
## Summary
- add shared `sendChatRequest` transport for streaming and non-stream responses
- refactor chat UI to append streamed tokens into a single assistant bubble and handle errors
- allow AJAX handler to parse JSON bodies and enqueue new transport script

## Testing
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`
- `node --check wp-ai-agent/assets/js/chat-transport.js`
- `node --check wp-ai-agent/assets/js/chat-frontend.js`
- `node --check wp-ai-agent/assets/js/chat-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_6899ea5b7bbc8320b281eb05872a4bff