### PR TITLE
Add persistent chat sessions with inactivity expiry

### DIFF
--- a/tests/session-expiry.html
+++ b/tests/session-expiry.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Session Expiry Demo</title>
+<link rel="stylesheet" href="../wp-ai-agent/assets/css/chat.css">
+<div id="wp-ai-agent-root" data-wpai-chat-root></div>
+<script src="../wp-ai-agent/assets/js/chat-transport.js"></script>
+<script src="../wp-ai-agent/assets/js/chat-frontend.js"></script>
+<script>
+window.WPAI_CONFIG = {
+    ajax: '#',
+    assets: '../wp-ai-agent/assets',
+    nonce: 'test',
+    expiry: 0.01,
+    i18n: { finished: 'This chat has finished due to inactivity. Click “Start new chat” to continue.', startNew: 'Start new chat' },
+    agentNames: ['Test Bot']
+};
+</script>

--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -22,3 +22,6 @@
 .ai-agent-msg.typing .typing-dots span:nth-child(3){ animation-delay:.4s; }
 @keyframes wpai-blink { 0%,80%,100%{opacity:0;}40%{opacity:1;} }
 .ai-agent-name{font-weight:600;}
+.ai-agent-msg.system{background:#e8f0fe;font-style:italic;}
+.ai-agent-finish{margin:8px 0;}
+.ai-agent-finish button{background:#25D366;color:#fff;border:none;padding:6px 12px;border-radius:4px;cursor:pointer;}

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -64,6 +64,8 @@
         const send = win.querySelector('button');
         const list = win.querySelector(listSelector);
         let convo = [];
+        let expiryTimer = null;
+        let allowNew = false;
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
@@ -92,16 +94,80 @@
             return m;
         }
 
+        function addBot(text, system){
+            const m = document.createElement('div');
+            m.className = 'ai-agent-msg bot' + (system ? ' system' : '');
+            m.innerHTML = '<span class="ai-agent-name">'+agentName+(system?'':'')+':</span> '+text;
+            list.appendChild(m);
+            scrollBottom();
+        }
+
+        function renderConv(arr){
+            arr.forEach(function(m){
+                if(m.role === 'user'){ addUser(m.content); }
+                else { addBot(m.content, m.system); }
+            });
+        }
+
+        function clearTimer(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer=null; } }
+        function startTimer(){
+            clearTimer();
+            const mins = parseInt(config.expiry || 20, 10);
+            expiryTimer = setTimeout(function(){ showFinished(true); }, Math.max(1, mins)*60*1000);
+        }
+
+        function showFinished(addMsg){
+            if(addMsg){ addBot((config.i18n&&config.i18n.finished)||'This chat has finished due to inactivity. Click “Start new chat” to continue.', true); }
+            const wrap = document.createElement('div');
+            wrap.className = 'ai-agent-finish';
+            const btn = document.createElement('button');
+            btn.textContent = (config.i18n&&config.i18n.startNew)||'Start new chat';
+            btn.addEventListener('click', function(){
+                allowNew = true;
+                clearTimer();
+                try{
+                    const fd = new FormData();
+                    fd.append('action','ai_agent_end_session');
+                    fd.append('nonce', config.nonce || '');
+                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                }catch(e){}
+            });
+            wrap.appendChild(btn);
+            list.appendChild(wrap);
+            scrollBottom();
+        }
+
+        function bootstrap(){
+            const fd = new FormData();
+            fd.append('action','ai_agent_get_session');
+            fd.append('nonce', config.nonce || '');
+            fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'})
+                .then(r=>r.json())
+                .then(res=>{
+                    if(!res || !res.success){ return; }
+                    const data = res.data || {};
+                    if(Array.isArray(data.conversation)){
+                        convo = data.conversation;
+                        renderConv(convo);
+                    }
+                    if(data.status === 'active'){ startTimer(); }
+                    if(data.status === 'expired'){ showFinished(false); }
+                })
+                .catch(()=>{});
+        }
+
         async function sendMsg(msg){
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
             let textNode;
+            const newFlag = allowNew ? 1 : 0; allowNew = false;
+            startTimer();
             try{
                 const full = await window.WPAI.sendChatRequest({
                     url: config.ajax + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
-                    body: { visitor: visitor, message: msg, conversation: convo },
+                    body: { visitor: visitor, message: msg, new_session: newFlag, nonce: config.nonce },
                     onToken: function(tok){
                         if(!textNode){
                             typingEl.classList.remove('typing');
@@ -112,7 +178,8 @@
                             textNode.textContent += tok;
                         }
                         scrollBottom();
-                    }
+                    },
+                    onDone: function(){ startTimer(); }
                 });
                 convo.push({role:'user',content:msg});
                 convo.push({role:'assistant',content:full});
@@ -157,6 +224,7 @@
                 }
             });
         }
+        bootstrap();
     }
 
     function boot(){

--- a/wp-ai-agent/includes/class-ai-agent-admin.php
+++ b/wp-ai-agent/includes/class-ai-agent-admin.php
@@ -37,6 +37,7 @@ class Ai_Agent_Admin {
         $out['debug']      = ! empty( $input['debug'] ) ? 1 : 0;
         $out['sound']      = ! empty( $input['sound'] ) ? 1 : 0;
         $out['remove']     = ! empty( $input['remove'] ) ? 1 : 0;
+        $out['chat_expiry_minutes'] = isset( $input['chat_expiry_minutes'] ) ? max( 1, (int) $input['chat_expiry_minutes'] ) : 20;
         return $out;
     }
 

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -7,6 +7,10 @@ class Ai_Agent_AJAX {
     public function __construct() {
         add_action( 'wp_ajax_ai_agent_chat', [ $this, 'chat' ] );
         add_action( 'wp_ajax_nopriv_ai_agent_chat', [ $this, 'chat' ] );
+        add_action( 'wp_ajax_ai_agent_get_session', [ $this, 'get_session' ] );
+        add_action( 'wp_ajax_nopriv_ai_agent_get_session', [ $this, 'get_session' ] );
+        add_action( 'wp_ajax_ai_agent_end_session', [ $this, 'end_session' ] );
+        add_action( 'wp_ajax_nopriv_ai_agent_end_session', [ $this, 'end_session' ] );
     }
 
     protected function rate_limit( $visitor_id ) {
@@ -18,32 +22,103 @@ class Ai_Agent_AJAX {
         set_transient( $key, time(), 2 );
     }
 
+    public function get_session() {
+        check_ajax_referer( 'wpai_agent', 'nonce' );
+        $settings = wp_ai_agent_get_settings();
+        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
+        $visitor  = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
+        $ip_hash  = ai_agent_ip_hash();
+        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
+        if ( ! $found ) {
+            wp_send_json_success( [ 'status' => 'none' ] );
+        }
+        $row  = $found['row'];
+        $conv = json_decode( $row->conversation, true ) ?: [];
+        if ( $found['expired'] && ! $row->ended ) {
+            $finish = [
+                'role'    => 'assistant',
+                'content' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'ts'      => time(),
+                'system'  => true,
+            ];
+            $conv[] = $finish;
+            Ai_Agent_DB::update_session( $row->id, $conv, 1, $visitor ?: $row->visitor_id );
+            wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
+        }
+        if ( empty( $row->visitor_id ) && $visitor ) {
+            Ai_Agent_DB::update_session( $row->id, $conv, 0, $visitor );
+        }
+        wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
+    }
+
+    public function end_session() {
+        check_ajax_referer( 'wpai_agent', 'nonce' );
+        $visitor = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
+        $ip_hash = ai_agent_ip_hash();
+        $settings = wp_ai_agent_get_settings();
+        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
+        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
+        if ( $found && ! $found['row']->ended ) {
+            $conv = json_decode( $found['row']->conversation, true ) ?: [];
+            $conv[] = [
+                'role'    => 'assistant',
+                'content' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'ts'      => time(),
+                'system'  => true,
+            ];
+            Ai_Agent_DB::update_session( $found['row']->id, $conv, 1, $visitor ?: $found['row']->visitor_id );
+        }
+        wp_send_json_success();
+    }
+
     public function chat() {
         nocache_headers();
-        $input = file_get_contents( 'php://input' );
-        $json  = json_decode( $input, true );
-        if ( is_array( $json ) ) {
-            $visitor      = sanitize_text_field( $json['visitor'] ?? '' );
-            $message      = sanitize_textarea_field( $json['message'] ?? '' );
-            $conversation = isset( $json['conversation'] ) ? (array) $json['conversation'] : [];
-        } else {
-            $visitor      = sanitize_text_field( $_POST['visitor'] ?? '' );
-            $message      = sanitize_textarea_field( $_POST['message'] ?? '' );
-            $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+        $input  = file_get_contents( 'php://input' );
+        $json   = json_decode( $input, true );
+        $visitor = sanitize_text_field( $json['visitor'] ?? '' );
+        $message = sanitize_textarea_field( $json['message'] ?? '' );
+        $force   = ! empty( $json['new_session'] );
+        $nonce   = sanitize_text_field( $json['nonce'] ?? '' );
+        if ( ! wp_verify_nonce( $nonce, 'wpai_agent' ) ) {
+            wp_send_json_error( [ 'error' => 'invalid_nonce' ], 403 );
         }
         $this->rate_limit( $visitor );
 
         $settings = wp_ai_agent_get_settings();
+        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
         $handbook = Ai_Agent_Handbooks::get_prompt();
-        $system = $handbook;
+        $system   = $handbook;
         if ( ! empty( $settings['quote_rules'] ) ) {
             $system .= "\nQuote rules:\n" . $settings['quote_rules'];
         }
+        $ip_hash = ai_agent_ip_hash();
+        $found   = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
+        if ( $found && $found['expired'] ) {
+            $old = json_decode( $found['row']->conversation, true ) ?: [];
+            if ( ! $found['row']->ended ) {
+                $old[] = [ 'role' => 'assistant', 'content' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ), 'ts' => time(), 'system' => true ];
+                Ai_Agent_DB::update_session( $found['row']->id, $old, 1, $visitor ?: $found['row']->visitor_id );
+            }
+            $found = null;
+        }
+        if ( $force || ! $found ) {
+            $session_id  = Ai_Agent_DB::create_session( $visitor, $ip_hash );
+            $conversation = [];
+        } else {
+            $session_id  = $found['row']->id;
+            $conversation = json_decode( $found['row']->conversation, true ) ?: [];
+            if ( empty( $found['row']->visitor_id ) && $visitor ) {
+                Ai_Agent_DB::update_session( $session_id, $conversation, 0, $visitor );
+            }
+        }
+
+        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        Ai_Agent_DB::update_session( $session_id, $conversation, 0, $visitor );
+
         $messages = [ [ 'role' => 'system', 'content' => $system ] ];
         foreach ( $conversation as $c ) {
             $messages[] = [ 'role' => $c['role'], 'content' => $c['content'] ];
         }
-        $messages[] = [ 'role' => 'user', 'content' => $message ];
 
         header( 'Content-Type: text/event-stream' );
         header( 'Cache-Control: no-cache' );
@@ -51,7 +126,8 @@ class Ai_Agent_AJAX {
 
         $response = $this->stream_api( $settings, $messages );
 
-        Ai_Agent_DB::save_chat( $visitor, array_merge( $conversation, [ [ 'role' => 'user', 'content' => $message, 'ts' => time() ], [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ] ] ) );
+        $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
+        Ai_Agent_DB::update_session( $session_id, $conversation, 0, $visitor );
         wp_die();
     }
 

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -9,13 +9,76 @@ class Ai_Agent_DB {
         return $wpdb->prefix . 'ai_agent_chats';
     }
 
-    public static function create_tables() {
+    public static function maybe_upgrade_schema() {
         global $wpdb;
         $table = self::table_name();
+        $cols  = $wpdb->get_col( "SHOW COLUMNS FROM $table", 0 );
+        if ( ! in_array( 'ip_hash', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN ip_hash VARCHAR(128) NOT NULL DEFAULT '' AFTER visitor_id" );
+        }
+        if ( ! in_array( 'last_activity', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN last_activity DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER timestamp" );
+        }
+        if ( ! in_array( 'ended', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN ended TINYINT(1) NOT NULL DEFAULT 0" );
+        }
+    }
+
+    public static function create_tables() {
+        global $wpdb;
+        $table   = self::table_name();
         $charset = $wpdb->get_charset_collate();
-        $sql = "CREATE TABLE $table (\n            id INT NOT NULL AUTO_INCREMENT,\n            visitor_id VARCHAR(64) NOT NULL,\n            timestamp DATETIME NOT NULL,\n            conversation LONGTEXT NOT NULL,\n            PRIMARY KEY  (id),\n            KEY visitor_id (visitor_id)\n        ) $charset;";
+        $sql     = "CREATE TABLE $table (\n            id INT NOT NULL AUTO_INCREMENT,\n            visitor_id VARCHAR(64) NOT NULL,\n            ip_hash VARCHAR(128) NOT NULL DEFAULT '',\n            timestamp DATETIME NOT NULL,\n            last_activity DATETIME NOT NULL,\n            conversation LONGTEXT NOT NULL,\n            ended TINYINT(1) NOT NULL DEFAULT 0,\n            PRIMARY KEY  (id),\n            KEY visitor_id (visitor_id),\n            KEY ip_hash (ip_hash)\n        ) $charset;";
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
+    }
+
+    public static function get_active_by_vid_or_ip( $visitor_id, $ip_hash, $expiry ) {
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE visitor_id=%s AND ended=0 ORDER BY id DESC LIMIT 1", $visitor_id ) );
+        $now   = current_time( 'timestamp', true );
+        $limit = (int) $expiry * MINUTE_IN_SECONDS;
+        if ( $row ) {
+            $expired = $row->last_activity && ( $now - strtotime( $row->last_activity ) > $limit );
+            return [ 'row' => $row, 'expired' => $expired ];
+        }
+        if ( $ip_hash ) {
+            $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE ip_hash=%s AND ended=0 ORDER BY id DESC LIMIT 1", $ip_hash ) );
+            if ( $row ) {
+                $expired = $row->last_activity && ( $now - strtotime( $row->last_activity ) > $limit );
+                return [ 'row' => $row, 'expired' => $expired ];
+            }
+        }
+        return null;
+    }
+
+    public static function create_session( $visitor_id, $ip_hash ) {
+        global $wpdb;
+        $wpdb->insert( self::table_name(), [
+            'visitor_id'   => $visitor_id,
+            'ip_hash'      => $ip_hash,
+            'timestamp'    => current_time( 'mysql', true ),
+            'last_activity'=> current_time( 'mysql', true ),
+            'conversation' => wp_json_encode( [] ),
+            'ended'        => 0,
+        ], [ '%s', '%s', '%s', '%s', '%s', '%d' ] );
+        return $wpdb->insert_id;
+    }
+
+    public static function update_session( $id, $conversation, $ended = 0, $visitor_id = null ) {
+        global $wpdb;
+        $data = [
+            'conversation'  => wp_json_encode( $conversation ),
+            'last_activity' => current_time( 'mysql', true ),
+            'ended'         => $ended ? 1 : 0,
+        ];
+        $format = [ '%s', '%s', '%d' ];
+        if ( null !== $visitor_id ) {
+            $data['visitor_id'] = $visitor_id;
+            $format[]           = '%s';
+        }
+        $wpdb->update( self::table_name(), $data, [ 'id' => (int) $id ], $format, [ '%d' ] );
     }
 
     public static function drop_tables() {

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -30,6 +30,12 @@ class Ai_Agent_Render {
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
+            'nonce'      => wp_create_nonce( 'wpai_agent' ),
+            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
+            'i18n'       => [
+                'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'startNew' => __( 'Start new chat', 'wp-ai-agent' ),
+            ],
         ];
     }
 

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -6,11 +6,12 @@
 if ( ! function_exists( 'wp_ai_agent_get_settings' ) ) {
     function wp_ai_agent_get_settings() {
         $defaults = [
-            'openai_key' => '',
-            'alt_key'    => '',
-            'base_url'   => 'https://api.openai.com/v1/chat/completions',
-            'model'      => 'gpt-4o-mini',
-            'quote_rules'=> '',
+            'openai_key'            => '',
+            'alt_key'               => '',
+            'base_url'              => 'https://api.openai.com/v1/chat/completions',
+            'model'                 => 'gpt-4o-mini',
+            'quote_rules'           => '',
+            'chat_expiry_minutes'   => 20,
         ];
         $opts = get_option( 'wp_ai_agent_settings', [] );
         return wp_parse_args( $opts, $defaults );
@@ -26,5 +27,29 @@ if ( ! function_exists( 'wp_ai_agent_encrypt' ) ) {
 if ( ! function_exists( 'wp_ai_agent_decrypt' ) ) {
     function wp_ai_agent_decrypt( $value ) {
         return Ai_Agent_Encryption::decrypt( $value );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_get_client_ip' ) ) {
+    function ai_agent_get_client_ip() {
+        $keys = [ 'HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR' ];
+        foreach ( $keys as $k ) {
+            if ( ! empty( $_SERVER[ $k ] ) ) {
+                $iplist = explode( ',', $_SERVER[ $k ] );
+                $ip     = trim( $iplist[0] );
+                if ( filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+                    return $ip;
+                }
+            }
+        }
+        return '0.0.0.0';
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ip_hash' ) ) {
+    function ai_agent_ip_hash( $ip = null ) {
+        $ip   = $ip ? $ip : ai_agent_get_client_ip();
+        $salt = defined( 'AUTH_SALT' ) ? AUTH_SALT : ( defined( 'LOGGED_IN_SALT' ) ? LOGGED_IN_SALT : wp_salt( 'auth' ) );
+        return hash_hmac( 'sha256', $ip, $salt );
     }
 }

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -41,6 +41,11 @@ $settings = wp_ai_agent_get_settings();
 <td><input type="number" id="retention" name="wp_ai_agent_settings[retention]" value="<?php echo esc_attr( $settings['retention'] ?? 30 ); ?>" /></td>
 </tr>
 <tr>
+<th scope="row"><label for="chat_expiry_minutes"><?php _e( 'Conversation inactivity timeout (minutes)', 'wp-ai-agent' ); ?></label></th>
+<td><input type="number" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" min="1" value="<?php echo esc_attr( $settings['chat_expiry_minutes'] ?? 20 ); ?>" />
+<p class="description"><?php _e( 'After this many minutes without activity, chats are marked finished. Returning visitors can start a new chat while the transcript remains.', 'wp-ai-agent' ); ?></p></td>
+</tr>
+<tr>
 <th scope="row"><?php _e( 'Remove uploaded handbooks on uninstall', 'wp-ai-agent' ); ?></th>
 <td><label><input type="checkbox" name="wp_ai_agent_remove_uploads" value="1" <?php checked( get_option( 'wp_ai_agent_remove_uploads' ), 1 ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
 </tr>

--- a/wp-ai-agent/wp-ai-agent.php
+++ b/wp-ai-agent/wp-ai-agent.php
@@ -31,6 +31,7 @@ require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-render.php';
  */
 function wp_ai_agent_activate() {
     Ai_Agent_DB::create_tables();
+    Ai_Agent_DB::maybe_upgrade_schema();
     Ai_Agent_DB::schedule_cron();
 }
 register_activation_hook( __FILE__, 'wp_ai_agent_activate' );
@@ -45,6 +46,7 @@ register_deactivation_hook( __FILE__, 'wp_ai_agent_deactivate' );
 
 // Initialize plugin pieces.
 add_action( 'plugins_loaded', function() {
+    Ai_Agent_DB::maybe_upgrade_schema();
     load_plugin_textdomain( 'wp-ai-agent', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
     new Ai_Agent_Admin();
     new Ai_Agent_AJAX();


### PR DESCRIPTION
## Summary
- hash visitor IPs and track chat session activity/expiry in database
- add admin setting for inactivity timeout and expose session APIs
- hydrate frontend sessions, show finished message and start new chat control

## Testing
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`
- `php -l wp-ai-agent/includes/class-ai-agent-db.php`
- `php -l wp-ai-agent/includes/helpers.php`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1c0a888c83209c15706ab460f8b6