### PR TITLE
Add persistent chat sessions with inactivity timeout

### DIFF
--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -22,3 +22,7 @@
 .ai-agent-msg.typing .typing-dots span:nth-child(3){ animation-delay:.4s; }
 @keyframes wpai-blink { 0%,80%,100%{opacity:0;}40%{opacity:1;} }
 .ai-agent-name{font-weight:600;}
+
+.ai-agent-msg.bot.system{background:#f1f1f1;font-style:italic;}
+.ai-agent-finished{margin:8px 4px;text-align:left;}
+.ai-agent-finished .ai-agent-btn-new{background:#34B7F1;color:#fff;border:none;padding:6px 12px;border-radius:6px;cursor:pointer;}

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -3,6 +3,8 @@
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
+    let expiryTimer = null;
+    let finished = false;
 
     function uuidv4(){
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){
@@ -92,7 +94,85 @@
             return m;
         }
 
+        function addBot(text, system){
+            const m = document.createElement('div');
+            m.className = 'ai-agent-msg bot' + (system ? ' system' : '');
+            m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ' + text;
+            list.appendChild(m);
+            scrollBottom();
+        }
+
+        function renderConversation(conv){
+            conv.forEach(function(m){
+                if(m.role === 'user'){
+                    addUser(m.content);
+                } else if(m.system){
+                    addBot(m.content, true);
+                } else {
+                    addBot(m.content);
+                }
+            });
+        }
+
+        function clearExpiry(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
+        function startExpiry(){
+            clearExpiry();
+            const minutes = parseInt(config.expiry || 20, 10);
+            expiryTimer = setTimeout(function(){ showFinishedBanner(); }, Math.max(1, minutes) * 60 * 1000);
+        }
+
+        function showFinishedBanner(existing){
+            if(!existing){
+                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
+            }
+            const wrap = document.createElement('div');
+            wrap.className = 'ai-agent-finished';
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'ai-agent-btn-new';
+            btn.textContent = (config.i18n && config.i18n.startNew) || 'Start new chat';
+            btn.addEventListener('click', function(){
+                finished = false;
+                convo = [];
+                if(config.ajax){
+                    const fd = new FormData();
+                    fd.append('action','ai_agent_end_session');
+                    fd.append('nonce', config.nonce || '');
+                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                }
+                wrap.remove();
+            });
+            wrap.appendChild(btn);
+            list.appendChild(wrap);
+            scrollBottom();
+            finished = true;
+            clearExpiry();
+        }
+
+        async function hydrate(){
+            if(!config.ajax){ return; }
+            const fd = new FormData();
+            fd.append('action','ai_agent_get_session');
+            fd.append('nonce', config.nonce || '');
+            try{
+                const res = await fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                const json = await res.json();
+                const data = json && json.data ? json.data : {};
+                if(Array.isArray(data.conversation)){
+                    convo = data.conversation;
+                    renderConversation(convo);
+                }
+                if(data.status === 'active'){
+                    startExpiry();
+                } else if(data.status === 'expired'){
+                    showFinishedBanner(true);
+                }
+            } catch(e){}
+        }
+
         async function sendMsg(msg){
+            if(finished){ finished = false; convo = []; }
+            startExpiry();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
@@ -112,7 +192,8 @@
                             textNode.textContent += tok;
                         }
                         scrollBottom();
-                    }
+                    },
+                    onDone: function(){ startExpiry(); }
                 });
                 convo.push({role:'user',content:msg});
                 convo.push({role:'assistant',content:full});
@@ -157,6 +238,8 @@
                 }
             });
         }
+
+        hydrate();
     }
 
     function boot(){

--- a/wp-ai-agent/includes/class-ai-agent-admin.php
+++ b/wp-ai-agent/includes/class-ai-agent-admin.php
@@ -33,6 +33,7 @@ class Ai_Agent_Admin {
         $out['model']      = sanitize_text_field( $input['model'] ?? '' );
         $out['quote_rules']= wp_kses_post( $input['quote_rules'] ?? '' );
         $out['retention']  = isset( $input['retention'] ) ? (int) $input['retention'] : 30;
+        $out['chat_expiry_minutes'] = isset( $input['chat_expiry_minutes'] ) ? max( 1, (int) $input['chat_expiry_minutes'] ) : 20;
         $out['enter_send'] = ! empty( $input['enter_send'] ) ? 1 : 0;
         $out['debug']      = ! empty( $input['debug'] ) ? 1 : 0;
         $out['sound']      = ! empty( $input['sound'] ) ? 1 : 0;

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -7,6 +7,10 @@ class Ai_Agent_AJAX {
     public function __construct() {
         add_action( 'wp_ajax_ai_agent_chat', [ $this, 'chat' ] );
         add_action( 'wp_ajax_nopriv_ai_agent_chat', [ $this, 'chat' ] );
+        add_action( 'wp_ajax_ai_agent_get_session', [ $this, 'get_session' ] );
+        add_action( 'wp_ajax_nopriv_ai_agent_get_session', [ $this, 'get_session' ] );
+        add_action( 'wp_ajax_ai_agent_end_session', [ $this, 'end_session' ] );
+        add_action( 'wp_ajax_nopriv_ai_agent_end_session', [ $this, 'end_session' ] );
     }
 
     protected function rate_limit( $visitor_id ) {
@@ -32,10 +36,21 @@ class Ai_Agent_AJAX {
             $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
         }
         $this->rate_limit( $visitor );
-
         $settings = wp_ai_agent_get_settings();
+        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
+        $ip_hash  = ai_agent_ip_hash();
+        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
+        $chat_id  = null;
+        if ( $found && ! $found->expired ) {
+            $chat_id     = (int) $found->row->id;
+            $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
+        } elseif ( $found && $found->expired ) {
+            $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
+            Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
+            $conversation = [];
+        }
         $handbook = Ai_Agent_Handbooks::get_prompt();
-        $system = $handbook;
+        $system   = $handbook;
         if ( ! empty( $settings['quote_rules'] ) ) {
             $system .= "\nQuote rules:\n" . $settings['quote_rules'];
         }
@@ -49,10 +64,56 @@ class Ai_Agent_AJAX {
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response = $this->stream_api( $settings, $messages );
-
-        Ai_Agent_DB::save_chat( $visitor, array_merge( $conversation, [ [ 'role' => 'user', 'content' => $message, 'ts' => time() ], [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ] ] ) );
+        $response      = $this->stream_api( $settings, $messages );
+        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
+        Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
         wp_die();
+    }
+
+    public function get_session() {
+        check_ajax_referer( 'wpai_agent', 'nonce' );
+        $settings = wp_ai_agent_get_settings();
+        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
+        $visitor  = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
+        $ip_hash  = ai_agent_ip_hash();
+        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
+        if ( ! $found ) {
+            wp_send_json_success( [ 'status' => 'none' ] );
+        }
+        $row  = $found->row;
+        $conv = json_decode( (string) $row->conversation, true ) ?: [];
+        if ( $found->expired && ! (int) $row->ended ) {
+            $conv[] = [
+                'role'   => 'assistant',
+                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'ts'     => time(),
+                'system' => true,
+            ];
+            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+            wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
+        }
+        wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
+    }
+
+    public function end_session() {
+        check_ajax_referer( 'wpai_agent', 'nonce' );
+        $visitor = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
+        if ( ! $visitor ) {
+            wp_send_json_success();
+        }
+        $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
+        if ( $row && $row->row && ! (int) $row->row->ended ) {
+            $conv = json_decode( (string) $row->row->conversation, true ) ?: [];
+            $conv[] = [
+                'role'   => 'assistant',
+                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'ts'     => time(),
+                'system' => true,
+            ];
+            Ai_Agent_DB::end_chat( (int) $row->row->id, $conv );
+        }
+        wp_send_json_success();
     }
 
     protected function stream_api( $settings, $messages ) {

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -11,9 +11,9 @@ class Ai_Agent_DB {
 
     public static function create_tables() {
         global $wpdb;
-        $table = self::table_name();
+        $table   = self::table_name();
         $charset = $wpdb->get_charset_collate();
-        $sql = "CREATE TABLE $table (\n            id INT NOT NULL AUTO_INCREMENT,\n            visitor_id VARCHAR(64) NOT NULL,\n            timestamp DATETIME NOT NULL,\n            conversation LONGTEXT NOT NULL,\n            PRIMARY KEY  (id),\n            KEY visitor_id (visitor_id)\n        ) $charset;";
+        $sql     = "CREATE TABLE $table (\n            id INT NOT NULL AUTO_INCREMENT,\n            visitor_id VARCHAR(64) NOT NULL,\n            ip_hash VARCHAR(128) NOT NULL DEFAULT '',\n            timestamp DATETIME NOT NULL,\n            last_activity DATETIME NOT NULL,\n            ended TINYINT(1) NOT NULL DEFAULT 0,\n            conversation LONGTEXT NOT NULL,\n            PRIMARY KEY  (id),\n            KEY visitor_id (visitor_id),\n            KEY ip_hash (ip_hash)\n        ) $charset;";
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
     }
@@ -24,13 +24,72 @@ class Ai_Agent_DB {
         $wpdb->query( "DROP TABLE IF EXISTS $table" );
     }
 
-    public static function save_chat( $visitor_id, $conversation ) {
+    public static function maybe_upgrade_schema() {
         global $wpdb;
-        $wpdb->insert( self::table_name(), [
-            'visitor_id'  => $visitor_id,
-            'timestamp'   => current_time( 'mysql' ),
-            'conversation'=> wp_json_encode( $conversation ),
-        ] );
+        $table = self::table_name();
+        $cols  = $wpdb->get_col( "SHOW COLUMNS FROM $table", 0 );
+        if ( ! in_array( 'ip_hash', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN ip_hash VARCHAR(128) NOT NULL DEFAULT '' AFTER visitor_id" );
+        }
+        if ( ! in_array( 'last_activity', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN last_activity DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00' AFTER timestamp" );
+        }
+        if ( ! in_array( 'ended', $cols, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN ended TINYINT(1) NOT NULL DEFAULT 0" );
+        }
+    }
+
+    public static function save_chat( $visitor_id, $ip_hash, $conversation, $chat_id = null, $ended = 0 ) {
+        global $wpdb;
+        $table = self::table_name();
+        $now   = current_time( 'mysql', true );
+        $data  = [
+            'visitor_id'    => $visitor_id,
+            'ip_hash'       => $ip_hash,
+            'conversation'  => wp_json_encode( $conversation ),
+            'last_activity' => $now,
+            'ended'         => $ended ? 1 : 0,
+        ];
+        if ( $chat_id ) {
+            $wpdb->update( $table, $data, [ 'id' => (int) $chat_id ], [ '%s','%s','%s','%s','%d' ], [ '%d' ] );
+            return $chat_id;
+        }
+        $data['timestamp'] = $now;
+        $wpdb->insert( $table, $data, [ '%s','%s','%s','%s','%d','%s' ] );
+        return (int) $wpdb->insert_id;
+    }
+
+    public static function get_active_by_vid_or_ip( $visitor_id, $ip_hash, $expiry_minutes ) {
+        global $wpdb;
+        $table = self::table_name();
+        $now   = current_time( 'timestamp', true );
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE visitor_id = %s AND ended = 0 ORDER BY id DESC LIMIT 1", $visitor_id ) );
+        if ( ! $row ) {
+            $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $table WHERE ip_hash = %s AND ended = 0 ORDER BY id DESC LIMIT 1", $ip_hash ) );
+            if ( ! $row ) {
+                return null;
+            }
+        }
+        $expired = false;
+        if ( $row->last_activity && ( $now - strtotime( $row->last_activity ) ) > (int) $expiry_minutes * 60 ) {
+            $expired = true;
+        }
+        return (object) [ 'row' => $row, 'expired' => $expired ];
+    }
+
+    public static function end_chat( $id, $conversation = null ) {
+        global $wpdb;
+        $table  = self::table_name();
+        $data   = [
+            'ended'         => 1,
+            'last_activity' => current_time( 'mysql', true ),
+        ];
+        $format = [ '%d', '%s' ];
+        if ( null !== $conversation ) {
+            $data['conversation'] = wp_json_encode( $conversation );
+            $format[] = '%s';
+        }
+        $wpdb->update( $table, $data, [ 'id' => (int) $id ], $format, [ '%d' ] );
     }
 
     public static function get_chats() {

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -30,6 +30,12 @@ class Ai_Agent_Render {
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
+            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
+            'nonce'      => wp_create_nonce( 'wpai_agent' ),
+            'i18n'       => [
+                'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'startNew' => __( 'Start new chat', 'wp-ai-agent' ),
+            ],
         ];
     }
 

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -11,6 +11,7 @@ if ( ! function_exists( 'wp_ai_agent_get_settings' ) ) {
             'base_url'   => 'https://api.openai.com/v1/chat/completions',
             'model'      => 'gpt-4o-mini',
             'quote_rules'=> '',
+            'chat_expiry_minutes' => 20,
         ];
         $opts = get_option( 'wp_ai_agent_settings', [] );
         return wp_parse_args( $opts, $defaults );
@@ -26,5 +27,37 @@ if ( ! function_exists( 'wp_ai_agent_encrypt' ) ) {
 if ( ! function_exists( 'wp_ai_agent_decrypt' ) ) {
     function wp_ai_agent_decrypt( $value ) {
         return Ai_Agent_Encryption::decrypt( $value );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_get_client_ip' ) ) {
+    function ai_agent_get_client_ip(): string {
+        $keys = [
+            'HTTP_CLIENT_IP',
+            'HTTP_X_FORWARDED_FOR',
+            'HTTP_X_FORWARDED',
+            'HTTP_X_CLUSTER_CLIENT_IP',
+            'HTTP_FORWARDED_FOR',
+            'HTTP_FORWARDED',
+            'REMOTE_ADDR',
+        ];
+        foreach ( $keys as $k ) {
+            if ( ! empty( $_SERVER[ $k ] ) ) {
+                $iplist = explode( ',', (string) $_SERVER[ $k ] );
+                $ip     = trim( $iplist[0] );
+                if ( filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+                    return $ip;
+                }
+            }
+        }
+        return '0.0.0.0';
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ip_hash' ) ) {
+    function ai_agent_ip_hash( ?string $ip = null ): string {
+        $ip   = $ip ?: ai_agent_get_client_ip();
+        $salt = defined( 'AUTH_SALT' ) ? AUTH_SALT : ( defined( 'LOGGED_IN_SALT' ) ? LOGGED_IN_SALT : wp_salt( 'auth' ) );
+        return hash_hmac( 'sha256', $ip, $salt );
     }
 }

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -37,6 +37,13 @@ $settings = wp_ai_agent_get_settings();
 <td><label><input type="checkbox" name="wp_ai_agent_settings[debug]" value="1" <?php checked( ! empty( $settings['debug'] ) ); ?> /> <?php _e( 'Enable', 'wp-ai-agent' ); ?></label></td>
 </tr>
 <tr>
+<th scope="row"><label for="chat_expiry_minutes"><?php _e( 'Conversation inactivity timeout (minutes)', 'wp-ai-agent' ); ?></label></th>
+<td>
+<input type="number" min="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( $settings['chat_expiry_minutes'] ?? 20 ); ?>" />
+<p class="description"><?php _e( 'If a visitor stops replying for this many minutes, the chat is marked finished. Returning users can start a new chat while the old transcript remains.', 'wp-ai-agent' ); ?></p>
+</td>
+</tr>
+<tr>
 <th scope="row"><label for="retention"><?php _e( 'Retention days', 'wp-ai-agent' ); ?></label></th>
 <td><input type="number" id="retention" name="wp_ai_agent_settings[retention]" value="<?php echo esc_attr( $settings['retention'] ?? 30 ); ?>" /></td>
 </tr>

--- a/wp-ai-agent/tests/session-expiry.html
+++ b/wp-ai-agent/tests/session-expiry.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Session Expiry Demo</title>
+<div id="wp-ai-agent-root" data-wpai-chat-root></div>
+<script>
+window.WPAI_CONFIG={ajax:'#',assets:'../assets',expiry:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+</script>
+<script src="../assets/js/chat-frontend.js"></script>

--- a/wp-ai-agent/wp-ai-agent.php
+++ b/wp-ai-agent/wp-ai-agent.php
@@ -31,6 +31,7 @@ require_once WP_AI_AGENT_DIR . 'includes/class-ai-agent-render.php';
  */
 function wp_ai_agent_activate() {
     Ai_Agent_DB::create_tables();
+    Ai_Agent_DB::maybe_upgrade_schema();
     Ai_Agent_DB::schedule_cron();
 }
 register_activation_hook( __FILE__, 'wp_ai_agent_activate' );
@@ -46,6 +47,7 @@ register_deactivation_hook( __FILE__, 'wp_ai_agent_deactivate' );
 // Initialize plugin pieces.
 add_action( 'plugins_loaded', function() {
     load_plugin_textdomain( 'wp-ai-agent', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    Ai_Agent_DB::maybe_upgrade_schema();
     new Ai_Agent_Admin();
     new Ai_Agent_AJAX();
     new Ai_Agent_Handbooks();


### PR DESCRIPTION
## Summary
- Support persistent chat sessions keyed by visitor ID and hashed IP with configurable inactivity timeout
- Add admin setting and schema upgrades for session metadata and expiry
- Implement frontend hydration, inactivity timer, and "Start new chat" workflow with finished banner

## Testing
- `php -l wp-ai-agent/includes/helpers.php`
- `php -l wp-ai-agent/includes/class-ai-agent-db.php`
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`
- `php -l wp-ai-agent/includes/class-ai-agent-admin.php`
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `php -l wp-ai-agent/wp-ai-agent.php`
- `node --check wp-ai-agent/assets/js/chat-frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_689b1c0a888c83209c15706ab460f8b6