### PR TITLE
Persist chat sessions and enforce inactivity expiry

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -15,7 +15,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';SameSite=Lax';
         return id;
     }
 
@@ -99,7 +99,7 @@
             let textNode;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -17,7 +17,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';SameSite=Lax';
         return id;
     }
 
@@ -38,6 +38,7 @@
 
     const agentName = getAgentName();
     const visitor = getVisitor();
+    const storageKey = 'wpai_conv_' + visitor;
 
     function init(root){
         if(root.dataset.wpaiInit){ return; }
@@ -66,6 +67,20 @@
         const send = win.querySelector('button');
         const list = win.querySelector(listSelector);
         let convo = [];
+
+        function saveLocal(){
+            try{ localStorage.setItem(storageKey, JSON.stringify(convo)); }catch(e){}
+        }
+
+        (function(){
+            try{
+                const raw = localStorage.getItem(storageKey);
+                if(raw){
+                    convo = JSON.parse(raw) || [];
+                    renderConversation(convo);
+                }
+            }catch(e){}
+        })();
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
@@ -114,16 +129,19 @@
             });
         }
 
-        function clearExpiry(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
-        function startExpiry(){
-            clearExpiry();
-            const minutes = parseInt(config.expiry || 20, 10);
+        function clearExpiryTimer(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
+        function startExpiryTimer(){
+            clearExpiryTimer();
+            const minutes = parseInt(config.expiryMinutes || 20, 10);
             expiryTimer = setTimeout(function(){ showFinishedBanner(); }, Math.max(1, minutes) * 60 * 1000);
         }
 
         function showFinishedBanner(existing){
             if(!existing){
-                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
+                const msg = (config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.';
+                addBot(msg, true);
+                convo.push({role:'assistant',content:msg,system:true});
+                saveLocal();
             }
             const wrap = document.createElement('div');
             wrap.className = 'ai-agent-finished';
@@ -134,11 +152,12 @@
             btn.addEventListener('click', function(){
                 finished = false;
                 convo = [];
-                if(config.ajax){
+                saveLocal();
+                if(config.ajaxUrl){
                     const fd = new FormData();
                     fd.append('action','ai_agent_end_session');
                     fd.append('nonce', config.nonce || '');
-                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                    fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 }
                 wrap.remove();
             });
@@ -146,24 +165,26 @@
             list.appendChild(wrap);
             scrollBottom();
             finished = true;
-            clearExpiry();
+            clearExpiryTimer();
         }
 
         async function hydrate(){
-            if(!config.ajax){ return; }
+            if(!config.ajaxUrl){ return; }
             const fd = new FormData();
             fd.append('action','ai_agent_get_session');
             fd.append('nonce', config.nonce || '');
             try{
-                const res = await fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                const res = await fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 const json = await res.json();
                 const data = json && json.data ? json.data : {};
                 if(Array.isArray(data.conversation)){
                     convo = data.conversation;
+                    list.innerHTML = '';
                     renderConversation(convo);
+                    saveLocal();
                 }
                 if(data.status === 'active'){
-                    startExpiry();
+                    startExpiryTimer();
                 } else if(data.status === 'expired'){
                     showFinishedBanner(true);
                 }
@@ -171,18 +192,20 @@
         }
 
         async function sendMsg(msg){
-            if(finished){ finished = false; convo = []; }
-            startExpiry();
+            if(finished){ finished = false; convo = []; saveLocal(); }
+            startExpiryTimer();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
             let textNode;
+            let firstChunk = true;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){
+                        if(firstChunk){ startExpiryTimer(); firstChunk = false; }
                         if(!textNode){
                             typingEl.classList.remove('typing');
                             typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
@@ -193,10 +216,10 @@
                         }
                         scrollBottom();
                     },
-                    onDone: function(){ startExpiry(); }
+                    onDone: function(){ startExpiryTimer(); }
                 });
-                convo.push({role:'user',content:msg});
                 convo.push({role:'assistant',content:full});
+                saveLocal();
                 if(!textNode){
                     typingEl.classList.remove('typing');
                     typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
@@ -214,6 +237,7 @@
                 err.className = 'ai-agent-msg bot';
                 err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
                 list.appendChild(err);
+                startExpiryTimer();
                 scrollBottom();
             } finally {
                 ta.disabled = false;
@@ -227,6 +251,8 @@
             if(!msg){ return; }
             ta.value = '';
             addUser(msg);
+            convo.push({role:'user',content:msg});
+            saveLocal();
             sendMsg(msg);
         });
 

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -27,13 +27,11 @@ class Ai_Agent_AJAX {
         $input = file_get_contents( 'php://input' );
         $json  = json_decode( $input, true );
         if ( is_array( $json ) ) {
-            $visitor      = sanitize_text_field( $json['visitor'] ?? '' );
-            $message      = sanitize_textarea_field( $json['message'] ?? '' );
-            $conversation = isset( $json['conversation'] ) ? (array) $json['conversation'] : [];
+            $visitor = sanitize_text_field( $json['visitor'] ?? '' );
+            $message = sanitize_textarea_field( $json['message'] ?? '' );
         } else {
-            $visitor      = sanitize_text_field( $_POST['visitor'] ?? '' );
-            $message      = sanitize_textarea_field( $_POST['message'] ?? '' );
-            $conversation = isset( $_POST['conversation'] ) ? json_decode( wp_unslash( $_POST['conversation'] ), true ) : [];
+            $visitor = sanitize_text_field( $_POST['visitor'] ?? '' );
+            $message = sanitize_textarea_field( $_POST['message'] ?? '' );
         }
         $this->rate_limit( $visitor );
         $settings = wp_ai_agent_get_settings();
@@ -41,31 +39,31 @@ class Ai_Agent_AJAX {
         $ip_hash  = ai_agent_ip_hash();
         $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
         $chat_id  = null;
+        $conversation = [];
         if ( $found && ! $found->expired ) {
             $chat_id     = (int) $found->row->id;
             $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
         } elseif ( $found && $found->expired ) {
-            $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
-            Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
-            $conversation = [];
+            Ai_Agent_DB::mark_finished_once( (int) $found->row->id, __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ) );
         }
         $handbook = Ai_Agent_Handbooks::get_prompt();
         $system   = $handbook;
         if ( ! empty( $settings['quote_rules'] ) ) {
             $system .= "\nQuote rules:\n" . $settings['quote_rules'];
         }
+        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $chat_id = Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
+
         $messages = [ [ 'role' => 'system', 'content' => $system ] ];
         foreach ( $conversation as $c ) {
             $messages[] = [ 'role' => $c['role'], 'content' => $c['content'] ];
         }
-        $messages[] = [ 'role' => 'user', 'content' => $message ];
 
         header( 'Content-Type: text/event-stream' );
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
-        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $response = $this->stream_api( $settings, $messages, $chat_id );
         $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
         wp_die();
@@ -83,14 +81,8 @@ class Ai_Agent_AJAX {
         }
         $row  = $found->row;
         $conv = json_decode( (string) $row->conversation, true ) ?: [];
-        if ( $found->expired && ! (int) $row->ended ) {
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+        if ( $found->expired ) {
+            $conv = Ai_Agent_DB::mark_finished_once( (int) $row->id, __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ) );
             wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
         }
         wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
@@ -103,20 +95,13 @@ class Ai_Agent_AJAX {
             wp_send_json_success();
         }
         $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
-        if ( $row && $row->row && ! (int) $row->row->ended ) {
-            $conv = json_decode( (string) $row->row->conversation, true ) ?: [];
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->row->id, $conv );
+        if ( $row && $row->row ) {
+            Ai_Agent_DB::mark_finished_once( (int) $row->row->id, __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ) );
         }
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
+    protected function stream_api( $settings, $messages, $chat_id ) {
         $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
         $open = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
@@ -139,8 +124,9 @@ class Ai_Agent_AJAX {
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
         $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer, $chat_id ) {
             $buffer .= $data;
+            Ai_Agent_DB::touch_activity( $chat_id );
             echo $data;
             @ob_flush();
             flush();

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -77,6 +77,11 @@ class Ai_Agent_DB {
         return (object) [ 'row' => $row, 'expired' => $expired ];
     }
 
+    public static function touch_activity( $id ) {
+        global $wpdb;
+        $wpdb->update( self::table_name(), [ 'last_activity' => current_time( 'mysql', true ) ], [ 'id' => (int) $id ], [ '%s' ], [ '%d' ] );
+    }
+
     public static function end_chat( $id, $conversation = null ) {
         global $wpdb;
         $table  = self::table_name();
@@ -90,6 +95,36 @@ class Ai_Agent_DB {
             $format[] = '%s';
         }
         $wpdb->update( $table, $data, [ 'id' => (int) $id ], $format, [ '%d' ] );
+    }
+
+    public static function mark_finished_once( $id, $message ) {
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare( 'SELECT ended, conversation FROM ' . self::table_name() . ' WHERE id = %d', $id ) );
+        if ( ! $row ) {
+            return [];
+        }
+        if ( (int) $row->ended ) {
+            return json_decode( (string) $row->conversation, true ) ?: [];
+        }
+        $conv = json_decode( (string) $row->conversation, true ) ?: [];
+        $conv[] = [
+            'role'    => 'assistant',
+            'content' => $message,
+            'ts'      => time(),
+            'system'  => true,
+        ];
+        $wpdb->update(
+            self::table_name(),
+            [
+                'conversation'  => wp_json_encode( $conv ),
+                'ended'         => 1,
+                'last_activity' => current_time( 'mysql', true ),
+            ],
+            [ 'id' => (int) $id ],
+            [ '%s', '%d', '%s' ],
+            [ '%d' ]
+        );
+        return $conv;
     }
 
     public static function get_chats() {

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -14,7 +14,7 @@ class Ai_Agent_Render {
         $settings = wp_ai_agent_get_settings();
 
         return [
-            'ajax'       => admin_url( 'admin-ajax.php' ),
+            'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
             'assets'     => WP_AI_AGENT_URL . 'assets',
             'enterSend'  => ! empty( $settings['enter_send'] ),
             'sound'      => ! empty( $settings['sound'] ),
@@ -30,7 +30,7 @@ class Ai_Agent_Render {
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
-            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
+            'expiryMinutes' => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
             'nonce'      => wp_create_nonce( 'wpai_agent' ),
             'i18n'       => [
                 'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -61,3 +61,32 @@ if ( ! function_exists( 'ai_agent_ip_hash' ) ) {
         return hash_hmac( 'sha256', $ip, $salt );
     }
 }
+
+if ( ! function_exists( 'ai_agent_uuidv4' ) ) {
+    function ai_agent_uuidv4(): string {
+        $data = random_bytes( 16 );
+        $data[6] = chr( ( ord( $data[6] ) & 0x0f ) | 0x40 );
+        $data[8] = chr( ( ord( $data[8] ) & 0x3f ) | 0x80 );
+        return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $data ), 4 ) );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ensure_vid_cookie' ) ) {
+    function ai_agent_ensure_vid_cookie() {
+        if ( headers_sent() ) {
+            return;
+        }
+        $vid = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
+        if ( ! $vid ) {
+            $vid = ai_agent_uuidv4();
+        }
+        setcookie( 'ai_agent_vid', $vid, [
+            'expires'  => time() + YEAR_IN_SECONDS,
+            'path'     => '/',
+            'secure'   => is_ssl(),
+            'samesite' => 'Lax',
+        ] );
+        $_COOKIE['ai_agent_vid'] = $vid;
+    }
+    add_action( 'init', 'ai_agent_ensure_vid_cookie', 1 );
+}

--- a/wp-ai-agent/tests/expiry-live.html
+++ b/wp-ai-agent/tests/expiry-live.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Expiry Live Demo</title>
+<div id="wp-ai-agent-root" data-wpai-chat-root></div>
+<script>
+window.WPAI_CONFIG={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.02,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+</script>
+<script src="../assets/js/chat-frontend.js"></script>

--- a/wp-ai-agent/tests/session-expiry.html
+++ b/wp-ai-agent/tests/session-expiry.html
@@ -3,6 +3,6 @@
 <title>Session Expiry Demo</title>
 <div id="wp-ai-agent-root" data-wpai-chat-root></div>
 <script>
-window.WPAI_CONFIG={ajax:'#',assets:'../assets',expiry:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+window.WPAI_CONFIG={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
 </script>
 <script src="../assets/js/chat-frontend.js"></script>


### PR DESCRIPTION
## Summary
- Ensure visitors receive a persistent `ai_agent_vid` cookie and store conversations keyed by visitor, hashing IPs server-side
- Introduce DB helpers for activity tracking and idempotent session finalization and expose new AJAX endpoints using these guards
- Rework frontend chat to hydrate from localStorage, restart an inactivity timer on activity, and append a "Start new chat" banner when the session expires
- Localize `ajaxUrl` and `expiryMinutes` to scripts and add a quick HTML demo for near-immediate expiry testing

## Testing
- `php -l includes/helpers.php`
- `php -l includes/class-ai-agent-db.php`
- `php -l includes/class-ai-agent-ajax.php`
- `php -l includes/class-ai-agent-render.php`
- `node --check assets/js/chat-frontend.js && echo 'frontend ok'`
- `node --check assets/js/chat-admin.js && echo 'admin ok'`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b259436388320a87c2bc9e7ac09bb