### PR TITLE
Persist chat sessions with inactivity timeout

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -1,5 +1,5 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
@@ -15,7 +15,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';samesite=lax';
         return id;
     }
 
@@ -99,7 +99,7 @@
             let textNode;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -1,10 +1,11 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
     let expiryTimer = null;
     let finished = false;
+    let allowNewSession = false;
 
     function uuidv4(){
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){
@@ -17,7 +18,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';samesite=lax';
         return id;
     }
 
@@ -38,6 +39,7 @@
 
     const agentName = getAgentName();
     const visitor = getVisitor();
+    const storageKey = 'wpai_conv_' + visitor;
 
     function init(root){
         if(root.dataset.wpaiInit){ return; }
@@ -66,6 +68,18 @@
         const send = win.querySelector('button');
         const list = win.querySelector(listSelector);
         let convo = [];
+
+        try {
+            const stored = localStorage.getItem(storageKey);
+            if(stored){
+                convo = JSON.parse(stored) || [];
+                renderConversation(convo);
+            }
+        } catch(e){}
+
+        function persist(){
+            try{ localStorage.setItem(storageKey, JSON.stringify(convo)); }catch(e){}
+        }
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
@@ -103,6 +117,7 @@
         }
 
         function renderConversation(conv){
+            list.innerHTML = '';
             conv.forEach(function(m){
                 if(m.role === 'user'){
                     addUser(m.content);
@@ -114,16 +129,19 @@
             });
         }
 
-        function clearExpiry(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
-        function startExpiry(){
-            clearExpiry();
-            const minutes = parseInt(config.expiry || 20, 10);
+        function clearExpiryTimer(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
+        function startExpiryTimer(){
+            clearExpiryTimer();
+            const minutes = parseInt(config.expiryMinutes || 20, 10);
             expiryTimer = setTimeout(function(){ showFinishedBanner(); }, Math.max(1, minutes) * 60 * 1000);
         }
 
         function showFinishedBanner(existing){
             if(!existing){
-                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
+                const msg = (config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.';
+                addBot(msg, true);
+                convo.push({role:'assistant',content:msg,ts:Math.floor(Date.now()/1000),system:true});
+                persist();
             }
             const wrap = document.createElement('div');
             wrap.className = 'ai-agent-finished';
@@ -132,38 +150,42 @@
             btn.className = 'ai-agent-btn-new';
             btn.textContent = (config.i18n && config.i18n.startNew) || 'Start new chat';
             btn.addEventListener('click', function(){
-                finished = false;
-                convo = [];
-                if(config.ajax){
+                if(config.ajaxUrl){
                     const fd = new FormData();
                     fd.append('action','ai_agent_end_session');
                     fd.append('nonce', config.nonce || '');
-                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                    fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 }
+                allowNewSession = true;
+                finished = false;
+                convo = [];
+                persist();
                 wrap.remove();
             });
             wrap.appendChild(btn);
             list.appendChild(wrap);
             scrollBottom();
             finished = true;
-            clearExpiry();
+            allowNewSession = true;
+            clearExpiryTimer();
         }
 
         async function hydrate(){
-            if(!config.ajax){ return; }
+            if(!config.ajaxUrl){ return; }
             const fd = new FormData();
             fd.append('action','ai_agent_get_session');
             fd.append('nonce', config.nonce || '');
             try{
-                const res = await fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                const res = await fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 const json = await res.json();
                 const data = json && json.data ? json.data : {};
                 if(Array.isArray(data.conversation)){
                     convo = data.conversation;
                     renderConversation(convo);
+                    persist();
                 }
                 if(data.status === 'active'){
-                    startExpiry();
+                    startExpiryTimer();
                 } else if(data.status === 'expired'){
                     showFinishedBanner(true);
                 }
@@ -171,15 +193,17 @@
         }
 
         async function sendMsg(msg){
-            if(finished){ finished = false; convo = []; }
-            startExpiry();
+            if(finished || allowNewSession){ finished = false; allowNewSession = false; convo = []; persist(); }
+            startExpiryTimer();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
             let textNode;
+            convo.push({role:'user',content:msg,ts:Math.floor(Date.now()/1000)});
+            persist();
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){
@@ -188,15 +212,16 @@
                             typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
                             textNode = document.createTextNode(tok);
                             typingEl.appendChild(textNode);
+                            startExpiryTimer();
                         } else {
                             textNode.textContent += tok;
                         }
                         scrollBottom();
                     },
-                    onDone: function(){ startExpiry(); }
+                    onDone: function(){ startExpiryTimer(); }
                 });
-                convo.push({role:'user',content:msg});
-                convo.push({role:'assistant',content:full});
+                convo.push({role:'assistant',content:full,ts:Math.floor(Date.now()/1000)});
+                persist();
                 if(!textNode){
                     typingEl.classList.remove('typing');
                     typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
@@ -215,6 +240,7 @@
                 err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
                 list.appendChild(err);
                 scrollBottom();
+                startExpiryTimer();
             } finally {
                 ta.disabled = false;
                 send.disabled = false;

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -44,9 +44,13 @@ class Ai_Agent_AJAX {
         if ( $found && ! $found->expired ) {
             $chat_id     = (int) $found->row->id;
             $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
+            Ai_Agent_DB::touch_activity( $chat_id );
         } elseif ( $found && $found->expired ) {
             $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
-            Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
+            Ai_Agent_DB::mark_finished_once(
+                (int) $found->row->id,
+                __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' )
+            );
             $conversation = [];
         }
         $handbook = Ai_Agent_Handbooks::get_prompt();
@@ -64,7 +68,7 @@ class Ai_Agent_AJAX {
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
+        $response      = $this->stream_api( $settings, $messages, $chat_id );
         $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
         $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
@@ -83,14 +87,11 @@ class Ai_Agent_AJAX {
         }
         $row  = $found->row;
         $conv = json_decode( (string) $row->conversation, true ) ?: [];
-        if ( $found->expired && ! (int) $row->ended ) {
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+        if ( $found->expired ) {
+            $conv = Ai_Agent_DB::mark_finished_once(
+                (int) $row->id,
+                __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' )
+            );
             wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
         }
         wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
@@ -103,20 +104,16 @@ class Ai_Agent_AJAX {
             wp_send_json_success();
         }
         $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
-        if ( $row && $row->row && ! (int) $row->row->ended ) {
-            $conv = json_decode( (string) $row->row->conversation, true ) ?: [];
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->row->id, $conv );
+        if ( $row && $row->row ) {
+            Ai_Agent_DB::mark_finished_once(
+                (int) $row->row->id,
+                __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' )
+            );
         }
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
+    protected function stream_api( $settings, $messages, $chat_id = null ) {
         $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
         $open = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
@@ -139,15 +136,21 @@ class Ai_Agent_AJAX {
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
         $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer, $chat_id ) {
             $buffer .= $data;
             echo $data;
+            if ( $chat_id ) {
+                Ai_Agent_DB::touch_activity( (int) $chat_id );
+            }
             @ob_flush();
             flush();
             return strlen( $data );
         } );
         curl_exec( $ch );
         curl_close( $ch );
+        if ( $chat_id ) {
+            Ai_Agent_DB::touch_activity( (int) $chat_id );
+        }
         $text = '';
         foreach ( explode( "\\n", $buffer ) as $line ) {
             if ( 0 === strpos( $line, 'data:' ) ) {

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -92,6 +92,49 @@ class Ai_Agent_DB {
         $wpdb->update( $table, $data, [ 'id' => (int) $id ], $format, [ '%d' ] );
     }
 
+    public static function touch_activity( int $id ): void {
+        if ( $id <= 0 ) {
+            return;
+        }
+        global $wpdb;
+        $table = self::table_name();
+        $wpdb->update( $table, [ 'last_activity' => current_time( 'mysql', true ) ], [ 'id' => $id ], [ '%s' ], [ '%d' ] );
+    }
+
+    public static function mark_finished_once( int $id, string $message ): array {
+        if ( $id <= 0 ) {
+            return [];
+        }
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT ended, conversation FROM $table WHERE id = %d", $id ) );
+        if ( ! $row ) {
+            return [];
+        }
+        $conv = json_decode( (string) $row->conversation, true ) ?: [];
+        if ( (int) $row->ended ) {
+            return $conv;
+        }
+        $conv[] = [
+            'role'    => 'assistant',
+            'content' => $message,
+            'ts'      => time(),
+            'system'  => true,
+        ];
+        $wpdb->update(
+            $table,
+            [
+                'conversation'  => wp_json_encode( $conv ),
+                'ended'         => 1,
+                'last_activity' => current_time( 'mysql', true ),
+            ],
+            [ 'id' => $id ],
+            [ '%s', '%d', '%s' ],
+            [ '%d' ]
+        );
+        return $conv;
+    }
+
     public static function get_chats() {
         global $wpdb;
         return $wpdb->get_results( "SELECT * FROM " . self::table_name() . " ORDER BY timestamp DESC" );

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -14,7 +14,7 @@ class Ai_Agent_Render {
         $settings = wp_ai_agent_get_settings();
 
         return [
-            'ajax'       => admin_url( 'admin-ajax.php' ),
+            'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
             'assets'     => WP_AI_AGENT_URL . 'assets',
             'enterSend'  => ! empty( $settings['enter_send'] ),
             'sound'      => ! empty( $settings['sound'] ),
@@ -30,8 +30,8 @@ class Ai_Agent_Render {
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
-            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
-            'nonce'      => wp_create_nonce( 'wpai_agent' ),
+            'expiryMinutes' => isset( $settings['chat_expiry_minutes'] ) ? max( 1, (int) $settings['chat_expiry_minutes'] ) : 20,
+            'nonce'         => wp_create_nonce( 'wpai_agent' ),
             'i18n'       => [
                 'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'startNew' => __( 'Start new chat', 'wp-ai-agent' ),
@@ -44,7 +44,7 @@ class Ai_Agent_Render {
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
         wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-frontend', 'WPAI_CONFIG', $this->config() );
+        wp_localize_script( 'wp-ai-agent-frontend', 'WPAIAgent', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-frontend' );
     }
 
@@ -57,7 +57,7 @@ class Ai_Agent_Render {
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
         wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-admin', 'WPAI_CONFIG', $this->config() );
+        wp_localize_script( 'wp-ai-agent-admin', 'WPAIAgent', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-admin' );
     }
 

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -61,3 +61,46 @@ if ( ! function_exists( 'ai_agent_ip_hash' ) ) {
         return hash_hmac( 'sha256', $ip, $salt );
     }
 }
+
+if ( ! function_exists( 'ai_agent_uuidv4' ) ) {
+    function ai_agent_uuidv4(): string {
+        if ( function_exists( 'wp_generate_uuid4' ) ) {
+            return wp_generate_uuid4();
+        }
+        return sprintf(
+            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+            wp_rand( 0, 0xffff ),
+            wp_rand( 0, 0xffff ),
+            wp_rand( 0, 0xffff ),
+            wp_rand( 0, 0x0fff ) | 0x4000,
+            wp_rand( 0, 0x3fff ) | 0x8000,
+            wp_rand( 0, 0xffff ),
+            wp_rand( 0, 0xffff ),
+            wp_rand( 0, 0xffff )
+        );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ensure_vid_cookie' ) ) {
+    function ai_agent_ensure_vid_cookie(): void {
+        if ( headers_sent() ) {
+            return;
+        }
+        $vid = $_COOKIE['ai_agent_vid'] ?? '';
+        if ( empty( $vid ) ) {
+            $vid = ai_agent_uuidv4();
+            setcookie(
+                'ai_agent_vid',
+                $vid,
+                [
+                    'expires'  => time() + YEAR_IN_SECONDS,
+                    'path'     => '/',
+                    'secure'   => is_ssl(),
+                    'samesite' => 'Lax',
+                ]
+            );
+            $_COOKIE['ai_agent_vid'] = $vid;
+        }
+    }
+    add_action( 'init', 'ai_agent_ensure_vid_cookie', 0 );
+}

--- a/wp-ai-agent/tests/expiry-live.html
+++ b/wp-ai-agent/tests/expiry-live.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Live Expiry Demo</title>
+<div id="wp-ai-agent-root" data-wpai-chat-root></div>
+<script>
+window.WPAIAgent={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.02,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+</script>
+<script src="../assets/js/chat-frontend.js"></script>

--- a/wp-ai-agent/tests/session-expiry.html
+++ b/wp-ai-agent/tests/session-expiry.html
@@ -3,6 +3,6 @@
 <title>Session Expiry Demo</title>
 <div id="wp-ai-agent-root" data-wpai-chat-root></div>
 <script>
-window.WPAI_CONFIG={ajax:'#',assets:'../assets',expiry:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+window.WPAIAgent={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
 </script>
 <script src="../assets/js/chat-frontend.js"></script>


### PR DESCRIPTION
## Summary
- Save a visitor UUID cookie and lookup chats by visitor or hashed IP
- Hydrate/persist conversations in localStorage and end stale sessions after inactivity
- Expose expiryMinutes config and add demo page for short timeout

## Testing
- `php -l includes/helpers.php`
- `php -l includes/class-ai-agent-render.php`
- `php -l includes/class-ai-agent-ajax.php`
- `node --check assets/js/chat-frontend.js`
- `node --check assets/js/chat-admin.js`
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689b259436388320a87c2bc9e7ac09bb