### PR TITLE
Persist chat sessions and enforce inactivity expiry

### DIFF
--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -5,6 +5,7 @@
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
     let expiryTimer = null;
     let finished = false;
+    let allowNew = false;
 
     function uuidv4(){
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g,function(c){
@@ -65,14 +66,25 @@
         const ta = win.querySelector('textarea');
         const send = win.querySelector('button');
         const list = win.querySelector(listSelector);
+        const storageKey = 'wpai_conv_' + visitor;
         let convo = [];
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
-        function addUser(text){
+        function persist(){ try{ localStorage.setItem(storageKey, JSON.stringify(convo)); }catch(e){} }
+
+        function hydrateLocal(){
+            try{ const raw = localStorage.getItem(storageKey); if(raw){ const arr = JSON.parse(raw); if(Array.isArray(arr) && arr.length){ convo = arr; renderConversation(convo); } } }catch(e){}
+        }
+
+        function clearMessages(){ list.innerHTML = ''; }
+
+        function addUser(text, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg user';
             m.textContent = text;
+            m.setAttribute('data-role','user');
+            if(ts){ m.setAttribute('data-ts', ts); }
             list.appendChild(m);
             scrollBottom();
         }
@@ -94,10 +106,12 @@
             return m;
         }
 
-        function addBot(text, system){
+        function addBot(text, system, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot' + (system ? ' system' : '');
             m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ' + text;
+            m.setAttribute('data-role','assistant');
+            if(ts){ m.setAttribute('data-ts', ts); }
             list.appendChild(m);
             scrollBottom();
         }
@@ -105,11 +119,11 @@
         function renderConversation(conv){
             conv.forEach(function(m){
                 if(m.role === 'user'){
-                    addUser(m.content);
+                    addUser(m.content, m.ts);
                 } else if(m.system){
-                    addBot(m.content, true);
+                    addBot(m.content, true, m.ts);
                 } else {
-                    addBot(m.content);
+                    addBot(m.content, false, m.ts);
                 }
             });
         }
@@ -122,8 +136,13 @@
         }
 
         function showFinishedBanner(existing){
+            if(finished){ return; }
+            let msg;
             if(!existing){
-                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
+                msg = (config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.';
+                addBot(msg, true, Math.floor(Date.now()/1000));
+                convo.push({role:'assistant', content:msg, ts:Math.floor(Date.now()/1000), system:true});
+                persist();
             }
             const wrap = document.createElement('div');
             wrap.className = 'ai-agent-finished';
@@ -132,8 +151,7 @@
             btn.className = 'ai-agent-btn-new';
             btn.textContent = (config.i18n && config.i18n.startNew) || 'Start new chat';
             btn.addEventListener('click', function(){
-                finished = false;
-                convo = [];
+                allowNew = true;
                 if(config.ajax){
                     const fd = new FormData();
                     fd.append('action','ai_agent_end_session');
@@ -159,8 +177,13 @@
                 const json = await res.json();
                 const data = json && json.data ? json.data : {};
                 if(Array.isArray(data.conversation)){
-                    convo = data.conversation;
-                    renderConversation(convo);
+                    const serverConv = data.conversation;
+                    if(JSON.stringify(serverConv) !== JSON.stringify(convo)){
+                        convo = serverConv;
+                        clearMessages();
+                        renderConversation(convo);
+                    }
+                    persist();
                 }
                 if(data.status === 'active'){
                     startExpiry();
@@ -171,18 +194,30 @@
         }
 
         async function sendMsg(msg){
-            if(finished){ finished = false; convo = []; }
+            if(finished || allowNew){
+                convo = [];
+                persist();
+                finished = false;
+                allowNew = false;
+            }
             startExpiry();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
+            const prevConv = convo.slice();
+            const tsUser = Math.floor(Date.now()/1000);
+            addUser(msg, tsUser);
+            convo.push({role:'user', content:msg, ts:tsUser});
+            persist();
             let textNode;
+            let firstChunk = true;
             try{
                 const full = await window.WPAI.sendChatRequest({
                     url: config.ajax + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
-                    body: { visitor: visitor, message: msg, conversation: convo },
+                    body: { visitor: visitor, message: msg, conversation: prevConv },
                     onToken: function(tok){
+                        if(firstChunk){ firstChunk = false; startExpiry(); }
                         if(!textNode){
                             typingEl.classList.remove('typing');
                             typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
@@ -195,8 +230,9 @@
                     },
                     onDone: function(){ startExpiry(); }
                 });
-                convo.push({role:'user',content:msg});
-                convo.push({role:'assistant',content:full});
+                const tsAssist = Math.floor(Date.now()/1000);
+                convo.push({role:'assistant', content:full, ts:tsAssist});
+                persist();
                 if(!textNode){
                     typingEl.classList.remove('typing');
                     typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
@@ -215,6 +251,7 @@
                 err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
                 list.appendChild(err);
                 scrollBottom();
+                startExpiry();
             } finally {
                 ta.disabled = false;
                 send.disabled = false;
@@ -226,7 +263,6 @@
             const msg = ta.value.trim();
             if(!msg){ return; }
             ta.value = '';
-            addUser(msg);
             sendMsg(msg);
         });
 
@@ -239,6 +275,7 @@
             });
         }
 
+        hydrateLocal();
         hydrate();
     }
 

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -41,14 +41,23 @@ class Ai_Agent_AJAX {
         $ip_hash  = ai_agent_ip_hash();
         $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
         $chat_id  = null;
+        $conversation = [];
         if ( $found && ! $found->expired ) {
-            $chat_id     = (int) $found->row->id;
+            $chat_id      = (int) $found->row->id;
             $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
         } elseif ( $found && $found->expired ) {
-            $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
-            Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
-            $conversation = [];
+            Ai_Agent_DB::mark_finished_once(
+                (int) $found->row->id,
+                [
+                    'role'   => 'assistant',
+                    'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                    'ts'     => time(),
+                    'system' => true,
+                ]
+            );
         }
+        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $chat_id = Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
         $handbook = Ai_Agent_Handbooks::get_prompt();
         $system   = $handbook;
         if ( ! empty( $settings['quote_rules'] ) ) {
@@ -58,14 +67,12 @@ class Ai_Agent_AJAX {
         foreach ( $conversation as $c ) {
             $messages[] = [ 'role' => $c['role'], 'content' => $c['content'] ];
         }
-        $messages[] = [ 'role' => 'user', 'content' => $message ];
 
         header( 'Content-Type: text/event-stream' );
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
-        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $response       = $this->stream_api( $settings, $messages, $chat_id );
         $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
         wp_die();
@@ -79,18 +86,20 @@ class Ai_Agent_AJAX {
         $ip_hash  = ai_agent_ip_hash();
         $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
         if ( ! $found ) {
-            wp_send_json_success( [ 'status' => 'none' ] );
+            wp_send_json_success( [ 'status' => 'none', 'conversation' => [] ] );
         }
         $row  = $found->row;
         $conv = json_decode( (string) $row->conversation, true ) ?: [];
-        if ( $found->expired && ! (int) $row->ended ) {
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+        if ( $found->expired ) {
+            $conv = Ai_Agent_DB::mark_finished_once(
+                (int) $row->id,
+                [
+                    'role'   => 'assistant',
+                    'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                    'ts'     => time(),
+                    'system' => true,
+                ]
+            );
             wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
         }
         wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
@@ -99,24 +108,24 @@ class Ai_Agent_AJAX {
     public function end_session() {
         check_ajax_referer( 'wpai_agent', 'nonce' );
         $visitor = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
-        if ( ! $visitor ) {
-            wp_send_json_success();
-        }
-        $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
-        if ( $row && $row->row && ! (int) $row->row->ended ) {
-            $conv = json_decode( (string) $row->row->conversation, true ) ?: [];
-            $conv[] = [
-                'role'   => 'assistant',
-                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
-                'ts'     => time(),
-                'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->row->id, $conv );
+        if ( $visitor ) {
+            $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
+            if ( $row && $row->row ) {
+                Ai_Agent_DB::mark_finished_once(
+                    (int) $row->row->id,
+                    [
+                        'role'   => 'assistant',
+                        'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                        'ts'     => time(),
+                        'system' => true,
+                    ]
+                );
+            }
         }
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
+    protected function stream_api( $settings, $messages, $chat_id = null ) {
         $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
         $open = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
@@ -139,9 +148,12 @@ class Ai_Agent_AJAX {
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
         $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer, $chat_id ) {
             $buffer .= $data;
             echo $data;
+            if ( $chat_id ) {
+                Ai_Agent_DB::touch_activity( (int) $chat_id );
+            }
             @ob_flush();
             flush();
             return strlen( $data );

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -71,10 +71,40 @@ class Ai_Agent_DB {
             }
         }
         $expired = false;
-        if ( $row->last_activity && ( $now - strtotime( $row->last_activity ) ) > (int) $expiry_minutes * 60 ) {
+        if ( $row->last_activity && ( $now - strtotime( $row->last_activity . ' UTC' ) ) > (int) $expiry_minutes * 60 ) {
             $expired = true;
         }
         return (object) [ 'row' => $row, 'expired' => $expired ];
+    }
+
+    public static function touch_activity( $id ) {
+        global $wpdb;
+        $wpdb->update( self::table_name(), [ 'last_activity' => current_time( 'mysql', true ) ], [ 'id' => (int) $id ], [ '%s' ], [ '%d' ] );
+    }
+
+    public static function mark_finished_once( $id, array $finish ) {
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT conversation, ended FROM $table WHERE id = %d", $id ) );
+        if ( ! $row ) {
+            return [];
+        }
+        $conv = json_decode( (string) $row->conversation, true ) ?: [];
+        if ( ! (int) $row->ended ) {
+            $conv[] = $finish;
+            $wpdb->update(
+                $table,
+                [
+                    'conversation'  => wp_json_encode( $conv ),
+                    'ended'         => 1,
+                    'last_activity' => current_time( 'mysql', true ),
+                ],
+                [ 'id' => (int) $id ],
+                [ '%s', '%d', '%s' ],
+                [ '%d' ]
+            );
+        }
+        return $conv;
     }
 
     public static function end_chat( $id, $conversation = null ) {

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -30,7 +30,7 @@ class Ai_Agent_Render {
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
-            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
+            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? max( 1, (int) $settings['chat_expiry_minutes'] ) : 20,
             'nonce'      => wp_create_nonce( 'wpai_agent' ),
             'i18n'       => [
                 'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -61,3 +61,32 @@ if ( ! function_exists( 'ai_agent_ip_hash' ) ) {
         return hash_hmac( 'sha256', $ip, $salt );
     }
 }
+
+if ( ! function_exists( 'ai_agent_uuidv4' ) ) {
+    function ai_agent_uuidv4(): string {
+        $d = random_bytes( 16 );
+        $d[6] = chr( ( ord( $d[6] ) & 0x0f ) | 0x40 );
+        $d[8] = chr( ( ord( $d[8] ) & 0x3f ) | 0x80 );
+        return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $d ), 4 ) );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ensure_vid_cookie' ) ) {
+    function ai_agent_ensure_vid_cookie(): string {
+        $name = 'ai_agent_vid';
+        $vid  = isset( $_COOKIE[ $name ] ) ? (string) $_COOKIE[ $name ] : '';
+        if ( ! preg_match( '/^[a-f0-9-]{36}$/', $vid ) ) {
+            $vid = ai_agent_uuidv4();
+            if ( ! headers_sent() ) {
+                $cookie = $name . '=' . rawurlencode( $vid ) . '; Max-Age=' . YEAR_IN_SECONDS . '; Path=/; SameSite=Lax';
+                if ( is_ssl() ) {
+                    $cookie .= '; Secure';
+                }
+                header( 'Set-Cookie: ' . $cookie, false );
+            }
+            $_COOKIE[ $name ] = $vid;
+        }
+        return $vid;
+    }
+}
+add_action( 'init', 'ai_agent_ensure_vid_cookie', 0 );

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -39,7 +39,7 @@ $settings = wp_ai_agent_get_settings();
 <tr>
 <th scope="row"><label for="chat_expiry_minutes"><?php _e( 'Conversation inactivity timeout (minutes)', 'wp-ai-agent' ); ?></label></th>
 <td>
-<input type="number" min="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( $settings['chat_expiry_minutes'] ?? 20 ); ?>" />
+<input type="number" min="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( max( 1, (int) ( $settings['chat_expiry_minutes'] ?? 20 ) ) ); ?>" />
 <p class="description"><?php _e( 'If a visitor stops replying for this many minutes, the chat is marked finished. Returning users can start a new chat while the old transcript remains.', 'wp-ai-agent' ); ?></p>
 </td>
 </tr>


### PR DESCRIPTION
## Summary
- Persist visitor conversations locally and reload on refresh while syncing with server sessions
- Add server/client inactivity handling that finalizes chats and enables clean "Start new chat" flows
- Ensure schema and settings support expiry with hashed IP and visitor cookie

## Testing
- `php -l includes/helpers.php`
- `php -l includes/class-ai-agent-db.php`
- `php -l includes/class-ai-agent-ajax.php`
- `php -l includes/class-ai-agent-render.php`
- `php -l templates/admin-settings.php`
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ac0f0788320a42fa14044bb5076