### PR TITLE
Persist chat sessions and handle inactivity expiry

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -1,5 +1,5 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
@@ -15,7 +15,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';SameSite=Lax';
         return id;
     }
 
@@ -99,7 +99,7 @@
             let textNode;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){

--- a/wp-ai-agent/assets/js/chat-frontend.js
+++ b/wp-ai-agent/assets/js/chat-frontend.js
@@ -1,5 +1,5 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
@@ -17,7 +17,7 @@
         const m = document.cookie.match(/ai_agent_vid=([^;]+)/);
         if(m){ return m[1]; }
         const id = uuidv4();
-        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60);
+        document.cookie = 'ai_agent_vid=' + id + ';path=/;max-age=' + (365*24*60*60) + ';SameSite=Lax';
         return id;
     }
 
@@ -38,6 +38,7 @@
 
     const agentName = getAgentName();
     const visitor = getVisitor();
+    const storageKey = 'wpai_conv_' + visitor;
 
     function init(root){
         if(root.dataset.wpaiInit){ return; }
@@ -114,16 +115,40 @@
             });
         }
 
+        function saveLocal(){ try{ localStorage.setItem(storageKey, JSON.stringify(convo)); }catch(e){} }
+        function hydrateLocal(){
+            try{ const a = JSON.parse(localStorage.getItem(storageKey)||'[]'); if(Array.isArray(a) && a.length){ convo=a; renderConversation(convo); } }catch(e){}
+        }
+        async function hydrateServer(){
+            if(!config.ajaxUrl){ return; }
+            const fd=new FormData(); fd.append('action','ai_agent_get_session'); fd.append('nonce', config.nonce||'');
+            try{
+                const res=await fetch(config.ajaxUrl,{method:'POST',body:fd,credentials:'same-origin'});
+                const json=await res.json(); const data=json && json.data ? json.data : {};
+                if(Array.isArray(data.conversation)){
+                    if(JSON.stringify(data.conversation)!==JSON.stringify(convo)){
+                        list.innerHTML=''; convo=data.conversation; renderConversation(convo);
+                    }
+                    saveLocal();
+                }
+                if(data.status==='active'){ startExpiry(); }
+                else if(data.status==='expired'){ showFinishedBanner(true); }
+            }catch(e){}
+        }
         function clearExpiry(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
         function startExpiry(){
             clearExpiry();
-            const minutes = parseInt(config.expiry || 20, 10);
-            expiryTimer = setTimeout(function(){ showFinishedBanner(); }, Math.max(1, minutes) * 60 * 1000);
+            const minutes = parseInt(config.expiryMinutes,10);
+            const ms = (isFinite(minutes) && minutes>0 ? minutes : 20) * 60 * 1000;
+            expiryTimer = setTimeout(function(){ showFinishedBanner(); }, ms);
         }
 
         function showFinishedBanner(existing){
             if(!existing){
-                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
+                const msg = (config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.';
+                addBot(msg, true);
+                convo.push({role:'assistant',content:msg,system:true});
+                saveLocal();
             }
             const wrap = document.createElement('div');
             wrap.className = 'ai-agent-finished';
@@ -134,13 +159,14 @@
             btn.addEventListener('click', function(){
                 finished = false;
                 convo = [];
-                if(config.ajax){
+                if(config.ajaxUrl){
                     const fd = new FormData();
                     fd.append('action','ai_agent_end_session');
                     fd.append('nonce', config.nonce || '');
-                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                    fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 }
                 wrap.remove();
+                saveLocal();
             });
             wrap.appendChild(btn);
             list.appendChild(wrap);
@@ -149,37 +175,18 @@
             clearExpiry();
         }
 
-        async function hydrate(){
-            if(!config.ajax){ return; }
-            const fd = new FormData();
-            fd.append('action','ai_agent_get_session');
-            fd.append('nonce', config.nonce || '');
-            try{
-                const res = await fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
-                const json = await res.json();
-                const data = json && json.data ? json.data : {};
-                if(Array.isArray(data.conversation)){
-                    convo = data.conversation;
-                    renderConversation(convo);
-                }
-                if(data.status === 'active'){
-                    startExpiry();
-                } else if(data.status === 'expired'){
-                    showFinishedBanner(true);
-                }
-            } catch(e){}
-        }
-
         async function sendMsg(msg){
-            if(finished){ finished = false; convo = []; }
+            if(finished){ finished = false; convo = []; saveLocal(); }
             startExpiry();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
-            let textNode;
+            convo.push({role:'user',content:msg});
+            saveLocal();
+            let textNode; let gotFirst=false;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){
@@ -191,12 +198,13 @@
                         } else {
                             textNode.textContent += tok;
                         }
+                        if(!gotFirst){ gotFirst=true; startExpiry(); }
                         scrollBottom();
                     },
                     onDone: function(){ startExpiry(); }
                 });
-                convo.push({role:'user',content:msg});
                 convo.push({role:'assistant',content:full});
+                saveLocal();
                 if(!textNode){
                     typingEl.classList.remove('typing');
                     typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
@@ -215,6 +223,7 @@
                 err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
                 list.appendChild(err);
                 scrollBottom();
+                startExpiry();
             } finally {
                 ta.disabled = false;
                 send.disabled = false;
@@ -239,7 +248,8 @@
             });
         }
 
-        hydrate();
+        hydrateLocal();
+        hydrateServer();
     }
 
     function boot(){

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -44,9 +44,15 @@ class Ai_Agent_AJAX {
         if ( $found && ! $found->expired ) {
             $chat_id     = (int) $found->row->id;
             $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
+            Ai_Agent_DB::touch_activity( $chat_id );
         } elseif ( $found && $found->expired ) {
             $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
-            Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
+            Ai_Agent_DB::mark_finished_once( (int) $found->row->id, [
+                'role'   => 'assistant',
+                'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
+                'ts'     => time(),
+                'system' => true,
+            ] );
             $conversation = [];
         }
         $handbook = Ai_Agent_Handbooks::get_prompt();
@@ -64,7 +70,7 @@ class Ai_Agent_AJAX {
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
+        $response      = $this->stream_api( $settings, $messages, $chat_id );
         $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
         $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
@@ -84,13 +90,14 @@ class Ai_Agent_AJAX {
         $row  = $found->row;
         $conv = json_decode( (string) $row->conversation, true ) ?: [];
         if ( $found->expired && ! (int) $row->ended ) {
-            $conv[] = [
+            $finish = [
                 'role'   => 'assistant',
                 'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'ts'     => time(),
                 'system' => true,
             ];
-            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+            Ai_Agent_DB::mark_finished_once( (int) $row->id, $finish );
+            $conv[] = $finish;
             wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
         }
         wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
@@ -104,19 +111,17 @@ class Ai_Agent_AJAX {
         }
         $row = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, ai_agent_ip_hash(), PHP_INT_MAX );
         if ( $row && $row->row && ! (int) $row->row->ended ) {
-            $conv = json_decode( (string) $row->row->conversation, true ) ?: [];
-            $conv[] = [
+            Ai_Agent_DB::mark_finished_once( (int) $row->row->id, [
                 'role'   => 'assistant',
                 'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'ts'     => time(),
                 'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->row->id, $conv );
+            ] );
         }
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
+    protected function stream_api( $settings, $messages, $chat_id = null ) {
         $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
         $open = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
@@ -139,15 +144,23 @@ class Ai_Agent_AJAX {
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
         $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+        $first  = true;
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer, &$first, $chat_id ) {
             $buffer .= $data;
             echo $data;
             @ob_flush();
             flush();
+            if ( $first && $chat_id ) {
+                Ai_Agent_DB::touch_activity( (int) $chat_id );
+                $first = false;
+            }
             return strlen( $data );
         } );
         curl_exec( $ch );
         curl_close( $ch );
+        if ( $chat_id ) {
+            Ai_Agent_DB::touch_activity( (int) $chat_id );
+        }
         $text = '';
         foreach ( explode( "\\n", $buffer ) as $line ) {
             if ( 0 === strpos( $line, 'data:' ) ) {

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -59,6 +59,33 @@ class Ai_Agent_DB {
         return (int) $wpdb->insert_id;
     }
 
+    public static function touch_activity( $id ) {
+        global $wpdb;
+        $wpdb->update( self::table_name(), [ 'last_activity' => current_time( 'mysql', true ) ], [ 'id' => (int) $id ], [ '%s' ], [ '%d' ] );
+    }
+
+    public static function mark_finished_once( $id, $finish ) {
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT ended, conversation FROM $table WHERE id = %d", $id ) );
+        if ( ! $row || (int) $row->ended ) {
+            return;
+        }
+        $conv   = json_decode( (string) $row->conversation, true ) ?: [];
+        $conv[] = $finish;
+        $wpdb->update(
+            $table,
+            [
+                'conversation'  => wp_json_encode( $conv ),
+                'ended'         => 1,
+                'last_activity' => current_time( 'mysql', true ),
+            ],
+            [ 'id' => (int) $id ],
+            [ '%s', '%d', '%s' ],
+            [ '%d' ]
+        );
+    }
+
     public static function get_active_by_vid_or_ip( $visitor_id, $ip_hash, $expiry_minutes ) {
         global $wpdb;
         $table = self::table_name();

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -14,25 +14,25 @@ class Ai_Agent_Render {
         $settings = wp_ai_agent_get_settings();
 
         return [
-            'ajax'       => admin_url( 'admin-ajax.php' ),
-            'assets'     => WP_AI_AGENT_URL . 'assets',
-            'enterSend'  => ! empty( $settings['enter_send'] ),
-            'sound'      => ! empty( $settings['sound'] ),
-            'agentNames' => [
+            'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+            'assets'       => WP_AI_AGENT_URL . 'assets',
+            'enterSend'    => ! empty( $settings['enter_send'] ),
+            'sound'        => ! empty( $settings['sound'] ),
+            'agentNames'   => [
                 'Jack Wilson',
                 'Olivia Nguyen',
                 'Liam O\'Connor',
                 'Chloe Smith',
                 'Noah Patel',
             ],
-            'debug'      => ! empty( $settings['debug'] ),
-            'selectors'  => [
+            'debug'        => ! empty( $settings['debug'] ),
+            'selectors'    => [
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
-            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
-            'nonce'      => wp_create_nonce( 'wpai_agent' ),
-            'i18n'       => [
+            'expiryMinutes'=> isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
+            'nonce'        => wp_create_nonce( 'wpai_agent' ),
+            'i18n'         => [
                 'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'startNew' => __( 'Start new chat', 'wp-ai-agent' ),
             ],
@@ -44,7 +44,7 @@ class Ai_Agent_Render {
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
         wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-frontend', 'WPAI_CONFIG', $this->config() );
+        wp_localize_script( 'wp-ai-agent-frontend', 'WPAIAgent', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-frontend' );
     }
 
@@ -57,7 +57,7 @@ class Ai_Agent_Render {
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
         wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-admin', 'WPAI_CONFIG', $this->config() );
+        wp_localize_script( 'wp-ai-agent-admin', 'WPAIAgent', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-admin' );
     }
 

--- a/wp-ai-agent/includes/helpers.php
+++ b/wp-ai-agent/includes/helpers.php
@@ -30,6 +30,35 @@ if ( ! function_exists( 'wp_ai_agent_decrypt' ) ) {
     }
 }
 
+if ( ! function_exists( 'ai_agent_uuidv4' ) ) {
+    function ai_agent_uuidv4(): string {
+        $d = random_bytes( 16 );
+        $d[6] = chr( ( ord( $d[6] ) & 0x0f ) | 0x40 );
+        $d[8] = chr( ( ord( $d[8] ) & 0x3f ) | 0x80 );
+        return vsprintf( '%s%s-%s-%s-%s-%s%s%s', str_split( bin2hex( $d ), 4 ) );
+    }
+}
+
+if ( ! function_exists( 'ai_agent_ensure_vid_cookie' ) ) {
+    function ai_agent_ensure_vid_cookie(): string {
+        $name = 'ai_agent_vid';
+        $vid  = $_COOKIE[ $name ] ?? '';
+        if ( ! preg_match( '/^[a-f0-9-]{36}$/', $vid ) ) {
+            $vid = ai_agent_uuidv4();
+            if ( ! headers_sent() ) {
+                $cookie = $name . '=' . rawurlencode( $vid ) . '; Max-Age=' . YEAR_IN_SECONDS . '; Path=/; SameSite=Lax';
+                if ( is_ssl() ) {
+                    $cookie .= '; Secure';
+                }
+                header( 'Set-Cookie: ' . $cookie, false );
+            }
+            $_COOKIE[ $name ] = $vid;
+        }
+        return $vid;
+    }
+}
+add_action( 'init', 'ai_agent_ensure_vid_cookie', 0 );
+
 if ( ! function_exists( 'ai_agent_get_client_ip' ) ) {
     function ai_agent_get_client_ip(): string {
         $keys = [

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -39,7 +39,7 @@ $settings = wp_ai_agent_get_settings();
 <tr>
 <th scope="row"><label for="chat_expiry_minutes"><?php _e( 'Conversation inactivity timeout (minutes)', 'wp-ai-agent' ); ?></label></th>
 <td>
-<input type="number" min="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( $settings['chat_expiry_minutes'] ?? 20 ); ?>" />
+<input type="number" min="1" step="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( max( 1, (int) ( $settings['chat_expiry_minutes'] ?? 20 ) ) ); ?>" />
 <p class="description"><?php _e( 'If a visitor stops replying for this many minutes, the chat is marked finished. Returning users can start a new chat while the old transcript remains.', 'wp-ai-agent' ); ?></p>
 </td>
 </tr>

--- a/wp-ai-agent/tests/session-expiry.html
+++ b/wp-ai-agent/tests/session-expiry.html
@@ -3,6 +3,6 @@
 <title>Session Expiry Demo</title>
 <div id="wp-ai-agent-root" data-wpai-chat-root></div>
 <script>
-window.WPAI_CONFIG={ajax:'#',assets:'../assets',expiry:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+window.WPAIAgent={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
 </script>
 <script src="../assets/js/chat-frontend.js"></script>


### PR DESCRIPTION
## Summary
- Persist conversations with visitor cookie and localStorage; hydrate from server via new `ai_agent_get_session` endpoint
- Enforce inactivity timeout and session finishing on client and server, with Start new chat button and DB schema helpers
- Expose `WPAIAgent` config with expiry minutes and localized strings

## Testing
- `php -l wp-ai-agent/includes/helpers.php`
- `php -l wp-ai-agent/includes/class-ai-agent-db.php`
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`
- `php -l wp-ai-agent/includes/class-ai-agent-render.php`
- `php -l wp-ai-agent/templates/admin-settings.php`
- `node --check wp-ai-agent/assets/js/chat-frontend.js && echo "frontend ok"`
- `node --check wp-ai-agent/assets/js/chat-admin.js && echo "admin ok"`


------
https://chatgpt.com/codex/tasks/task_e_689b2ac0f0788320a42fa14044bb5076