### PR TITLE
Implement inactivity-based chat expiry

### DIFF
--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -24,5 +24,5 @@
 .ai-agent-name{font-weight:600;}
 
 .ai-agent-msg.bot.system{background:#f1f1f1;font-style:italic;}
-.ai-agent-finished{margin:8px 4px;text-align:left;}
-.ai-agent-finished .ai-agent-btn-new{background:#34B7F1;color:#fff;border:none;padding:6px 12px;border-radius:6px;cursor:pointer;}
+.wpai-finished{display:flex;gap:8px;margin:8px 0;max-width:80%;background:#fff;border-radius:14px;padding:10px 12px}
+.wpai-finished .wpai-btn-start-new{border:0;border-radius:14px;padding:6px 10px;cursor:pointer}

--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -1,5 +1,5 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
@@ -99,7 +99,7 @@
             let textNode;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){

--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -1,9 +1,9 @@
 (function(){
-    const config = window.WPAI_CONFIG || {};
+    const config = window.WPAIAgent || {};
     const selectors = config.selectors || {};
     const rootSelector = selectors.chatRoot || '[data-wpai-chat-root]';
     const listSelector = selectors.messageList || '[data-wpai-message-list]';
-    let expiryTimer = null;
+    let expiryTimer = null, allowNewSession = false;
     let finished = false;
 
     function uuidv4(){
@@ -67,6 +67,10 @@
         const list = win.querySelector(listSelector);
         let convo = [];
 
+        function persistConversation(){
+            try{ localStorage.setItem('wpai_conversation', JSON.stringify(convo)); }catch(e){}
+        }
+
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
         function addUser(text){
@@ -114,72 +118,80 @@
             });
         }
 
-        function clearExpiry(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
-        function startExpiry(){
-            clearExpiry();
-            const minutes = parseInt(config.expiry || 20, 10);
-            expiryTimer = setTimeout(function(){ showFinishedBanner(); }, Math.max(1, minutes) * 60 * 1000);
+        function clearExpiryTimer(){ if(expiryTimer){ clearTimeout(expiryTimer); expiryTimer = null; } }
+        function startExpiryTimer(){
+            clearExpiryTimer();
+            const m = parseInt(config.expiryMinutes,10);
+            const ms = (isFinite(m) && m>0 ? m : 20) * 60 * 1000;
+            expiryTimer = setTimeout(showFinishedBanner, ms);
         }
 
-        function showFinishedBanner(existing){
-            if(!existing){
-                addBot((config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.', true);
-            }
+        function showFinishedBanner(){
+            if(finished){ return; }
+            const msg = (config.i18n && config.i18n.finished) || 'This chat has finished due to inactivity. Click “Start new chat” to continue.';
             const wrap = document.createElement('div');
-            wrap.className = 'ai-agent-finished';
+            wrap.className = 'ai-agent-msg bot system wpai-finished';
+            const span = document.createElement('span');
+            span.textContent = msg;
             const btn = document.createElement('button');
             btn.type = 'button';
-            btn.className = 'ai-agent-btn-new';
+            btn.className = 'wpai-btn-start-new';
             btn.textContent = (config.i18n && config.i18n.startNew) || 'Start new chat';
             btn.addEventListener('click', function(){
-                finished = false;
-                convo = [];
-                if(config.ajax){
-                    const fd = new FormData();
-                    fd.append('action','ai_agent_end_session');
-                    fd.append('nonce', config.nonce || '');
-                    fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
-                }
-                wrap.remove();
+                const fd = new FormData();
+                fd.append('action','ai_agent_end_session');
+                fd.append('nonce', config.nonce || '');
+                fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
+                allowNewSession = true;
+                clearExpiryTimer();
+                persistConversation();
             });
+            wrap.appendChild(span);
             wrap.appendChild(btn);
             list.appendChild(wrap);
             scrollBottom();
+            convo.push({role:'assistant', content:msg, system:true, ts:Math.floor(Date.now()/1000)});
+            persistConversation();
             finished = true;
-            clearExpiry();
         }
 
         async function hydrate(){
-            if(!config.ajax){ return; }
+            if(!config.ajaxUrl){ return; }
             const fd = new FormData();
             fd.append('action','ai_agent_get_session');
             fd.append('nonce', config.nonce || '');
             try{
-                const res = await fetch(config.ajax, {method:'POST', body:fd, credentials:'same-origin'});
+                const res = await fetch(config.ajaxUrl, {method:'POST', body:fd, credentials:'same-origin'});
                 const json = await res.json();
                 const data = json && json.data ? json.data : {};
                 if(Array.isArray(data.conversation)){
                     convo = data.conversation;
                     renderConversation(convo);
+                    persistConversation();
                 }
                 if(data.status === 'active'){
-                    startExpiry();
+                    startExpiryTimer();
                 } else if(data.status === 'expired'){
-                    showFinishedBanner(true);
+                    showFinishedBanner();
                 }
             } catch(e){}
         }
 
         async function sendMsg(msg){
-            if(finished){ finished = false; convo = []; }
-            startExpiry();
+            if(finished){
+                if(!allowNewSession){ return; }
+                finished = false;
+                allowNewSession = false;
+                convo = [];
+            }
+            startExpiryTimer();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
             let textNode;
             try{
                 const full = await window.WPAI.sendChatRequest({
-                    url: config.ajax + '?action=ai_agent_chat',
+                    url: config.ajaxUrl + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){
@@ -188,15 +200,17 @@
                             typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
                             textNode = document.createTextNode(tok);
                             typingEl.appendChild(textNode);
+                            startExpiryTimer();
                         } else {
                             textNode.textContent += tok;
                         }
                         scrollBottom();
                     },
-                    onDone: function(){ startExpiry(); }
+                    onDone: function(){ startExpiryTimer(); }
                 });
                 convo.push({role:'user',content:msg});
                 convo.push({role:'assistant',content:full});
+                persistConversation();
                 if(!textNode){
                     typingEl.classList.remove('typing');
                     typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
@@ -216,6 +230,7 @@
                 list.appendChild(err);
                 scrollBottom();
             } finally {
+                startExpiryTimer();
                 ta.disabled = false;
                 send.disabled = false;
                 scrollBottom();

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -44,6 +44,7 @@ class Ai_Agent_AJAX {
         if ( $found && ! $found->expired ) {
             $chat_id     = (int) $found->row->id;
             $conversation = json_decode( (string) $found->row->conversation, true ) ?: [];
+            Ai_Agent_DB::touch_activity( $chat_id ); // user send
         } elseif ( $found && $found->expired ) {
             $prev = json_decode( (string) $found->row->conversation, true ) ?: [];
             Ai_Agent_DB::end_chat( (int) $found->row->id, $prev );
@@ -64,7 +65,7 @@ class Ai_Agent_AJAX {
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
+        $response      = $this->stream_api( $settings, $messages, $chat_id );
         $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
         $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
@@ -74,23 +75,22 @@ class Ai_Agent_AJAX {
     public function get_session() {
         check_ajax_referer( 'wpai_agent', 'nonce' );
         $settings = wp_ai_agent_get_settings();
-        $expiry   = isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20;
+        $exp      = max( 1, (int) ( $settings['chat_expiry_minutes'] ?? 20 ) );
         $visitor  = isset( $_COOKIE['ai_agent_vid'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['ai_agent_vid'] ) ) : '';
         $ip_hash  = ai_agent_ip_hash();
-        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, $expiry );
-        if ( ! $found ) {
+        $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash, PHP_INT_MAX );
+        if ( ! $found || ! $found->row ) {
             wp_send_json_success( [ 'status' => 'none' ] );
         }
         $row  = $found->row;
         $conv = json_decode( (string) $row->conversation, true ) ?: [];
-        if ( $found->expired && ! (int) $row->ended ) {
-            $conv[] = [
+        if ( time() - strtotime( $row->last_activity . ' UTC' ) > $exp * 60 && ! (int) $row->ended ) {
+            $conv = Ai_Agent_DB::mark_finished_once( (int) $row->id, [
                 'role'   => 'assistant',
                 'content'=> __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'ts'     => time(),
                 'system' => true,
-            ];
-            Ai_Agent_DB::end_chat( (int) $row->id, $conv );
+            ] );
             wp_send_json_success( [ 'status' => 'expired', 'conversation' => $conv ] );
         }
         wp_send_json_success( [ 'status' => 'active', 'conversation' => $conv ] );
@@ -116,7 +116,7 @@ class Ai_Agent_AJAX {
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
+    protected function stream_api( $settings, $messages, $chat_id = null ) {
         $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
         $open = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
@@ -139,15 +139,23 @@ class Ai_Agent_AJAX {
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
         $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
+        $first  = true;
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer, &$first, $chat_id ) {
             $buffer .= $data;
             echo $data;
+            if ( $first && $chat_id ) {
+                Ai_Agent_DB::touch_activity( $chat_id ); // first token
+                $first = false;
+            }
             @ob_flush();
             flush();
             return strlen( $data );
         } );
         curl_exec( $ch );
         curl_close( $ch );
+        if ( $chat_id ) {
+            Ai_Agent_DB::touch_activity( $chat_id ); // finish
+        }
         $text = '';
         foreach ( explode( "\\n", $buffer ) as $line ) {
             if ( 0 === strpos( $line, 'data:' ) ) {

--- a/wp-ai-agent/includes/class-ai-agent-db.php
+++ b/wp-ai-agent/includes/class-ai-agent-db.php
@@ -92,6 +92,31 @@ class Ai_Agent_DB {
         $wpdb->update( $table, $data, [ 'id' => (int) $id ], $format, [ '%d' ] );
     }
 
+    public static function touch_activity( $id ) {
+        global $wpdb;
+        $table = self::table_name();
+        $wpdb->update( $table, [ 'last_activity' => gmdate( 'Y-m-d H:i:s' ) ], [ 'id' => (int) $id ], [ '%s' ], [ '%d' ] );
+    }
+
+    public static function mark_finished_once( $id, $message ) {
+        global $wpdb;
+        $table = self::table_name();
+        $row   = $wpdb->get_row( $wpdb->prepare( "SELECT ended, conversation FROM $table WHERE id = %d", $id ) );
+        if ( ! $row ) {
+            return [];
+        }
+        $conv = json_decode( (string) $row->conversation, true ) ?: [];
+        if ( ! (int) $row->ended ) {
+            $conv[] = $message;
+            $wpdb->update( $table, [
+                'conversation'  => wp_json_encode( $conv ),
+                'ended'         => 1,
+                'last_activity' => gmdate( 'Y-m-d H:i:s' ),
+            ], [ 'id' => (int) $id ], [ '%s','%d','%s' ], [ '%d' ] );
+        }
+        return $conv;
+    }
+
     public static function get_chats() {
         global $wpdb;
         return $wpdb->get_results( "SELECT * FROM " . self::table_name() . " ORDER BY timestamp DESC" );

--- a/wp-ai-agent/includes/class-ai-agent-render.php
+++ b/wp-ai-agent/includes/class-ai-agent-render.php
@@ -14,25 +14,25 @@ class Ai_Agent_Render {
         $settings = wp_ai_agent_get_settings();
 
         return [
-            'ajax'       => admin_url( 'admin-ajax.php' ),
-            'assets'     => WP_AI_AGENT_URL . 'assets',
-            'enterSend'  => ! empty( $settings['enter_send'] ),
-            'sound'      => ! empty( $settings['sound'] ),
-            'agentNames' => [
+            'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
+            'assets'      => WP_AI_AGENT_URL . 'assets',
+            'enterSend'   => ! empty( $settings['enter_send'] ),
+            'sound'       => ! empty( $settings['sound'] ),
+            'agentNames'  => [
                 'Jack Wilson',
                 'Olivia Nguyen',
                 'Liam O\'Connor',
                 'Chloe Smith',
                 'Noah Patel',
             ],
-            'debug'      => ! empty( $settings['debug'] ),
-            'selectors'  => [
+            'debug'       => ! empty( $settings['debug'] ),
+            'selectors'   => [
                 'chatRoot'    => '[data-wpai-chat-root]',
                 'messageList' => '[data-wpai-message-list]',
             ],
-            'expiry'     => isset( $settings['chat_expiry_minutes'] ) ? (int) $settings['chat_expiry_minutes'] : 20,
-            'nonce'      => wp_create_nonce( 'wpai_agent' ),
-            'i18n'       => [
+            'expiryMinutes' => max( 1, (int) ( $settings['chat_expiry_minutes'] ?? 20 ) ),
+            'nonce'       => wp_create_nonce( 'wpai_agent' ),
+            'i18n'        => [
                 'finished' => __( 'This chat has finished due to inactivity. Click “Start new chat” to continue.', 'wp-ai-agent' ),
                 'startNew' => __( 'Start new chat', 'wp-ai-agent' ),
             ],
@@ -43,9 +43,9 @@ class Ai_Agent_Render {
         wp_enqueue_style( 'wp-ai-agent', WP_AI_AGENT_URL . 'assets/css/chat.css', [], WP_AI_AGENT_VERSION );
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
-        wp_register_script( 'wp-ai-agent-frontend', WP_AI_AGENT_URL . 'assets/js/chat-frontend.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-frontend', 'WPAI_CONFIG', $this->config() );
-        wp_enqueue_script( 'wp-ai-agent-frontend' );
+        wp_register_script( 'wp-ai-agent-chat', WP_AI_AGENT_URL . 'assets/js/chat.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
+        wp_localize_script( 'wp-ai-agent-chat', 'WPAIAgent', $this->config() );
+        wp_enqueue_script( 'wp-ai-agent-chat' );
     }
 
     public function admin_assets( $hook ) {
@@ -57,7 +57,7 @@ class Ai_Agent_Render {
 
         wp_register_script( 'wp-ai-agent-transport', WP_AI_AGENT_URL . 'assets/js/chat-transport.js', [], WP_AI_AGENT_VERSION, true );
         wp_register_script( 'wp-ai-agent-admin', WP_AI_AGENT_URL . 'assets/js/chat-admin.js', [ 'wp-ai-agent-transport' ], WP_AI_AGENT_VERSION, true );
-        wp_localize_script( 'wp-ai-agent-admin', 'WPAI_CONFIG', $this->config() );
+        wp_localize_script( 'wp-ai-agent-admin', 'WPAIAgent', $this->config() );
         wp_enqueue_script( 'wp-ai-agent-admin' );
     }
 

--- a/wp-ai-agent/templates/admin-settings.php
+++ b/wp-ai-agent/templates/admin-settings.php
@@ -39,7 +39,7 @@ $settings = wp_ai_agent_get_settings();
 <tr>
 <th scope="row"><label for="chat_expiry_minutes"><?php _e( 'Conversation inactivity timeout (minutes)', 'wp-ai-agent' ); ?></label></th>
 <td>
-<input type="number" min="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( $settings['chat_expiry_minutes'] ?? 20 ); ?>" />
+<input type="number" min="1" step="1" id="chat_expiry_minutes" name="wp_ai_agent_settings[chat_expiry_minutes]" value="<?php echo esc_attr( max( 1, (int) ( $settings['chat_expiry_minutes'] ?? 20 ) ) ); ?>" />
 <p class="description"><?php _e( 'If a visitor stops replying for this many minutes, the chat is marked finished. Returning users can start a new chat while the old transcript remains.', 'wp-ai-agent' ); ?></p>
 </td>
 </tr>

--- a/wp-ai-agent/tests/session-expiry.html
+++ b/wp-ai-agent/tests/session-expiry.html
@@ -3,6 +3,6 @@
 <title>Session Expiry Demo</title>
 <div id="wp-ai-agent-root" data-wpai-chat-root></div>
 <script>
-window.WPAI_CONFIG={ajax:'#',assets:'../assets',expiry:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
+window.WPAIAgent={ajaxUrl:'#',assets:'../assets',expiryMinutes:0.01,nonce:'x',agentNames:['Demo'],selectors:{chatRoot:'#wp-ai-agent-root',messageList:'[data-wpai-message-list]'},i18n:{finished:'This chat has finished due to inactivity. Click “Start new chat” to continue.',startNew:'Start new chat'}};
 </script>
-<script src="../assets/js/chat-frontend.js"></script>
+<script src="../assets/js/chat.js"></script>


### PR DESCRIPTION
## Summary
- localize chat script with `expiryMinutes` and translated finished/start labels
- add server-side session expiry with single-touch activity tracking
- restartable inactivity timer and finish banner with "Start new chat" button

## Testing
- `php -l includes/class-ai-agent-render.php`
- `php -l templates/admin-settings.php`
- `php -l includes/class-ai-agent-ajax.php`
- `php -l includes/class-ai-agent-db.php`
- `node --check assets/js/chat.js`
- `node --check assets/js/chat-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689b2bac22048320b97311c6177d6602