### PR TITLE
Fix streaming persistence and conversation handling

### DIFF
--- a/wp-ai-agent/assets/js/chat-admin.js
+++ b/wp-ai-agent/assets/js/chat-admin.js
@@ -70,7 +70,12 @@
         function addUser(text){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg user';
-            m.textContent = text;
+            m.dataset.role = 'user';
+            m.dataset.ts = Date.now();
+            const span = document.createElement('span');
+            span.className = 'wpai-msg';
+            span.textContent = text;
+            m.appendChild(span);
             list.appendChild(m);
             scrollBottom();
         }
@@ -86,6 +91,8 @@
         function showTyping(){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot typing';
+            m.dataset.role = 'assistant';
+            m.dataset.ts = Date.now();
             m.innerHTML = '<span class="ai-agent-name">'+agentName+'</span> is typing <span class="typing-dots"><span></span><span></span><span></span></span>';
             list.appendChild(m);
             scrollBottom();
@@ -105,9 +112,8 @@
                     onToken: function(tok){
                         if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
-                            textNode = document.createTextNode(tok);
-                            typingEl.appendChild(textNode);
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"></span>';
+                            textNode = typingEl.querySelector('.wpai-msg').appendChild(document.createTextNode(tok));
                         } else {
                             textNode.textContent += tok;
                         }
@@ -118,7 +124,7 @@
                 convo.push({role:'assistant',content:full});
                 if(!textNode){
                     typingEl.classList.remove('typing');
-                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
+                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg">'+full+'</span>';
                 }
                 try{
                     const q = JSON.parse(full);

--- a/wp-ai-agent/assets/js/chat-transport.js
+++ b/wp-ai-agent/assets/js/chat-transport.js
@@ -7,37 +7,28 @@
       const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body), signal: ctrl.signal });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const ctype = (res.headers.get('content-type') || '').toLowerCase();
-      if (streamPreferred && (res.body && (ctype.includes('text/event-stream') || ctype.includes('application/json')))) {
+      if (streamPreferred && res.body && (ctype.includes('text/event-stream') || ctype.includes('application/json'))) {
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
-        let done, value, buf = '';
-        while (true) {
-          ({done, value} = await reader.read());
+        let buf = '';
+        let finished = false;
+        while (!finished) {
+          const {done, value} = await reader.read();
           if (done) break;
           buf += decoder.decode(value, {stream:true});
-          let idx;
-          while ((idx = buf.indexOf('\n')) >= 0) {
-            const line = buf.slice(0, idx).trim();
-            buf = buf.slice(idx+1);
-            if (!line) continue;
-            const dataLine = line.startsWith('data:') ? line.slice(5).trim() : line;
-            if (dataLine === '[DONE]') { onDone && onDone(full); return full; }
+          const parts = buf.split('\n');
+          buf = parts.pop();
+          for (const line of parts) {
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '[DONE]') { finished = true; break; }
             try {
-              const obj = JSON.parse(dataLine);
-              const choice = obj.choices && obj.choices[0];
-              const delta = choice && (choice.delta?.content ?? choice.message?.content ?? '');
-              if (delta) {
-                full += delta;
-                onToken && onToken(delta);
-              }
+              const j = JSON.parse(payload);
+              const delta = j.choices?.[0]?.delta?.content || '';
+              if (delta) { full += delta; onToken && onToken(delta); }
             } catch {}
           }
         }
-        try {
-          const obj = JSON.parse(buf);
-          const content = obj?.choices?.[0]?.message?.content ?? '';
-          if (content) { full += content; onToken && onToken(content); }
-        } catch {}
         onDone && onDone(full);
         return full;
       }

--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -59,14 +59,13 @@
         const list = win.querySelector(listSelector);
         let convo = [];
 
-        function saveLocal(){
+        function persistConversation(){
             const arr = [];
             list.querySelectorAll('.ai-agent-msg').forEach(el => {
-                let text = el.textContent;
-                const prefix = agentName + ':';
-                if((el.dataset.role||'') === 'assistant' && text.startsWith(prefix)){
-                    text = text.slice(prefix.length).trim();
-                }
+                if(el.classList.contains('typing')){ return; }
+                const msgEl = el.querySelector('.wpai-msg');
+                const text = msgEl ? msgEl.textContent.trim() : '';
+                if(!text){ return; }
                 arr.push({
                     role: el.dataset.role || (el.classList.contains('user') ? 'user' : 'assistant'),
                     content: text,
@@ -79,15 +78,18 @@
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
-        function addUser(text){
+        function addUser(text, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg user';
             m.dataset.role = 'user';
-            m.dataset.ts = Date.now();
-            m.textContent = text;
+            m.dataset.ts = ts || Date.now();
+            const span = document.createElement('span');
+            span.className = 'wpai-msg';
+            span.textContent = text;
+            m.appendChild(span);
             list.appendChild(m);
             scrollBottom();
-            saveLocal();
+            persistConversation();
         }
 
         function renderQuote(q){
@@ -101,31 +103,42 @@
         function showTyping(){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot typing';
+            m.dataset.role = 'assistant';
+            m.dataset.ts = Date.now();
             m.innerHTML = '<span class="ai-agent-name">'+agentName+'</span> is typing <span class="typing-dots"><span></span><span></span><span></span></span>';
             list.appendChild(m);
             scrollBottom();
             return m;
         }
 
-        function addBot(text, system){
+        function addBot(text, system, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot' + (system ? ' system' : '');
             m.dataset.role = 'assistant';
-            m.dataset.ts = Date.now();
-            m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ' + text;
+            m.dataset.ts = ts || Date.now();
+            const name = document.createElement('span');
+            name.className = 'ai-agent-name';
+            name.textContent = agentName + ':';
+            const msg = document.createElement('span');
+            msg.className = 'wpai-msg';
+            msg.textContent = text;
+            m.appendChild(name);
+            m.appendChild(document.createTextNode(' '));
+            m.appendChild(msg);
             list.appendChild(m);
             scrollBottom();
-            saveLocal();
+            persistConversation();
         }
 
         function renderConversation(conv){
             conv.forEach(function(m){
+                const text = m.content || m.message || m.text || '';
                 if(m.role === 'user'){
-                    addUser(m.content);
+                    addUser(text, m.ts);
                 } else if(m.system){
-                    addBot(m.content, true);
+                    addBot(text, true, m.ts);
                 } else {
-                    addBot(m.content);
+                    addBot(text, false, m.ts);
                 }
             });
         }
@@ -135,6 +148,7 @@
             if(cached){
                 convo = JSON.parse(cached) || [];
                 renderConversation(convo);
+                persistConversation();
             }
         }catch(e){}
 
@@ -187,7 +201,7 @@
                     convo = data.conversation;
                     list.innerHTML = '';
                     renderConversation(convo);
-                    saveLocal();
+                    persistConversation();
                 }
                 if(data.status === 'active'){
                     startExpiry();
@@ -212,9 +226,8 @@
                     onToken: function(tok){
                         if(!textNode){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
-                            textNode = document.createTextNode(tok);
-                            typingEl.appendChild(textNode);
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"></span>';
+                            textNode = typingEl.querySelector('.wpai-msg').appendChild(document.createTextNode(tok));
                         } else {
                             textNode.textContent += tok;
                         }
@@ -226,7 +239,7 @@
                 convo.push({role:'assistant',content:full});
                 if(!textNode){
                     typingEl.classList.remove('typing');
-                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
+                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg">'+full+'</span>';
                 }
                 try{
                     const q = JSON.parse(full);
@@ -235,7 +248,7 @@
                         if(textNode){ textNode.textContent = ''; }
                     }
                 }catch(e){}
-                saveLocal();
+                persistConversation();
             } catch(e){
                 typingEl.remove();
                 const err = document.createElement('div');

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -14,7 +14,7 @@ class Ai_Agent_AJAX {
     }
 
     protected function rate_limit( $visitor_id ) {
-        $key = 'ai_agent_last_' . $visitor_id;
+        $key  = 'ai_agent_last_' . $visitor_id;
         $last = get_transient( $key );
         if ( $last ) {
             wp_send_json_error( [ 'error' => 'rate_limited' ], 429 );
@@ -41,7 +41,7 @@ class Ai_Agent_AJAX {
         $found    = Ai_Agent_DB::get_active_by_vid_or_ip( $visitor, $ip_hash );
         $chat_id  = null;
         if ( $found ) {
-            $chat_id     = (int) $found->id;
+            $chat_id      = (int) $found->id;
             $conversation = json_decode( (string) $found->conversation, true ) ?: [];
         }
         $handbook = Ai_Agent_Handbooks::get_prompt();
@@ -55,13 +55,22 @@ class Ai_Agent_AJAX {
         }
         $messages[] = [ 'role' => 'user', 'content' => $message ];
 
+        // Persist the user message before streaming so it is not lost.
+        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
+        $chat_id        = Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
+
         header( 'Content-Type: text/event-stream' );
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
+        ignore_user_abort( true );
+        @set_time_limit( 0 );
 
-        $response      = $this->stream_api( $settings, $messages );
-        $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
-        $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
+        $assistant_buffer = '';
+        $this->stream_api( $settings, $messages, $assistant_buffer );
+
+        if ( '' !== $assistant_buffer ) {
+            $conversation[] = [ 'role' => 'assistant', 'content' => $assistant_buffer, 'ts' => time() ];
+        }
         Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
         wp_die();
     }
@@ -97,11 +106,11 @@ class Ai_Agent_AJAX {
         wp_send_json_success();
     }
 
-    protected function stream_api( $settings, $messages ) {
-        $alt = wp_ai_agent_decrypt( $settings['alt_key'] );
-        $open = wp_ai_agent_decrypt( $settings['openai_key'] );
+    protected function stream_api( $settings, $messages, &$assistant_buffer ) {
+        $alt   = wp_ai_agent_decrypt( $settings['alt_key'] );
+        $open  = wp_ai_agent_decrypt( $settings['openai_key'] );
         $model = $settings['model'] ?: 'gpt-4o-mini';
-        $url = $alt ? 'https://api.probex.top/v1/chat/completions' : 'https://api.openai.com/v1/chat/completions';
+        $url   = $alt ? 'https://api.probex.top/v1/chat/completions' : 'https://api.openai.com/v1/chat/completions';
         if ( ! empty( $settings['base_url'] ) && ! $alt ) {
             $url = $settings['base_url'];
         }
@@ -109,39 +118,44 @@ class Ai_Agent_AJAX {
             'Content-Type: application/json',
             'Authorization: Bearer ' . ( $alt ? $alt : $open ),
         ];
-        $body = [
-            'model'    => $alt ? $model : $model,
-            'messages' => $messages,
-            'stream'   => true,
+        $max_tokens = isset( $settings['max_tokens'] ) ? (int) $settings['max_tokens'] : 0;
+        $body       = [
+            'model'       => $alt ? $model : $model,
+            'messages'    => $messages,
+            'stream'      => true,
+            'max_tokens'  => $max_tokens < 800 ? 800 : $max_tokens,
+            'temperature' => isset( $settings['temperature'] ) ? (float) $settings['temperature'] : 0.7,
         ];
         $ch = curl_init( $url );
         curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
         curl_setopt( $ch, CURLOPT_POST, true );
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
-        $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
-            $buffer .= $data;
+        $sse_buf = '';
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$sse_buf, &$assistant_buffer ) {
             echo $data;
             @ob_flush();
             flush();
+            $sse_buf .= $data;
+            while ( false !== ( $pos = strpos( $sse_buf, "\n" ) ) ) {
+                $line    = trim( substr( $sse_buf, 0, $pos ) );
+                $sse_buf = substr( $sse_buf, $pos + 1 );
+                if ( '' === $line || 0 !== strpos( $line, 'data:' ) ) {
+                    continue;
+                }
+                $payload = trim( substr( $line, 5 ) );
+                if ( '[DONE]' === $payload ) {
+                    return strlen( $data );
+                }
+                $json = json_decode( $payload, true );
+                if ( isset( $json['choices'][0]['delta']['content'] ) ) {
+                    $assistant_buffer .= $json['choices'][0]['delta']['content'];
+                }
+            }
             return strlen( $data );
         } );
         curl_exec( $ch );
         curl_close( $ch );
-        $text = '';
-        foreach ( explode( "\\n", $buffer ) as $line ) {
-            if ( 0 === strpos( $line, 'data:' ) ) {
-                $payload = trim( substr( $line, 5 ) );
-                if ( '[DONE]' === $payload ) {
-                    break;
-                }
-                $json = json_decode( $payload, true );
-                if ( isset( $json['choices'][0]['delta']['content'] ) ) {
-                    $text .= $json['choices'][0]['delta']['content'];
-                }
-            }
-        }
-        return $text;
     }
 }
+


### PR DESCRIPTION
## Summary
- Persist assistant replies after streaming ends so chat history reloads fully
- Stream and buffer SSE responses on the client to prevent truncated replies
- Add `.wpai-msg` message spans and local conversation persistence to avoid blank bubbles

## Testing
- `php -l wp-ai-agent/includes/class-ai-agent-ajax.php`
- `node --check wp-ai-agent/assets/js/chat.js`
- `node --check wp-ai-agent/assets/js/chat-transport.js`
- `node --check wp-ai-agent/assets/js/chat-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_689b3d1b8d5483209069ea09ec82e97d