### PR TITLE
Fix chat streaming persistence

### DIFF
--- a/wp-ai-agent/assets/js/chat-transport.js
+++ b/wp-ai-agent/assets/js/chat-transport.js
@@ -10,34 +10,24 @@
       if (streamPreferred && (res.body && (ctype.includes('text/event-stream') || ctype.includes('application/json')))) {
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
-        let done, value, buf = '';
+        let buf = '';
         while (true) {
-          ({done, value} = await reader.read());
+          const {done, value} = await reader.read();
           if (done) break;
           buf += decoder.decode(value, {stream:true});
-          let idx;
-          while ((idx = buf.indexOf('\n')) >= 0) {
-            const line = buf.slice(0, idx).trim();
-            buf = buf.slice(idx+1);
-            if (!line) continue;
-            const dataLine = line.startsWith('data:') ? line.slice(5).trim() : line;
-            if (dataLine === '[DONE]') { onDone && onDone(full); return full; }
+          const lines = buf.split('\n');
+          for (const line of lines) {
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '[DONE]') { onDone && onDone(full); return full; }
             try {
-              const obj = JSON.parse(dataLine);
-              const choice = obj.choices && obj.choices[0];
-              const delta = choice && (choice.delta?.content ?? choice.message?.content ?? '');
-              if (delta) {
-                full += delta;
-                onToken && onToken(delta);
-              }
+              const j = JSON.parse(payload);
+              const delta = j.choices?.[0]?.delta?.content || '';
+              if (delta) { full += delta; onToken && onToken(delta); }
             } catch {}
           }
+          buf = buf.endsWith('\n') ? '' : buf.substring(buf.lastIndexOf('\n')+1);
         }
-        try {
-          const obj = JSON.parse(buf);
-          const content = obj?.choices?.[0]?.message?.content ?? '';
-          if (content) { full += content; onToken && onToken(content); }
-        } catch {}
         onDone && onDone(full);
         return full;
       }

--- a/wp-ai-agent/assets/js/chat.js
+++ b/wp-ai-agent/assets/js/chat.js
@@ -59,17 +59,14 @@
         const list = win.querySelector(listSelector);
         let convo = [];
 
-        function saveLocal(){
+        function persistConversation(){
             const arr = [];
             list.querySelectorAll('.ai-agent-msg').forEach(el => {
-                let text = el.textContent;
-                const prefix = agentName + ':';
-                if((el.dataset.role||'') === 'assistant' && text.startsWith(prefix)){
-                    text = text.slice(prefix.length).trim();
-                }
+                const txt = (el.querySelector('.wpai-msg')?.textContent || '').trim();
+                if(!txt){ return; }
                 arr.push({
                     role: el.dataset.role || (el.classList.contains('user') ? 'user' : 'assistant'),
-                    content: text,
+                    content: txt,
                     ts: parseInt(el.dataset.ts || Date.now(),10),
                     system: el.classList.contains('system')
                 });
@@ -79,15 +76,19 @@
 
         function scrollBottom(){ list.scrollTop = list.scrollHeight; }
 
-        function addUser(text){
+        function addUser(text, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg user';
             m.dataset.role = 'user';
-            m.dataset.ts = Date.now();
-            m.textContent = text;
+            m.dataset.ts = ts || Date.now();
+            const span = document.createElement('span');
+            span.className = 'wpai-msg';
+            span.textContent = text;
+            m.appendChild(span);
             list.appendChild(m);
             scrollBottom();
-            saveLocal();
+            persistConversation();
+            return m;
         }
 
         function renderQuote(q){
@@ -101,31 +102,35 @@
         function showTyping(){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot typing';
-            m.innerHTML = '<span class="ai-agent-name">'+agentName+'</span> is typing <span class="typing-dots"><span></span><span></span><span></span></span>';
+            m.dataset.role = 'assistant';
+            m.dataset.ts = Date.now();
+            m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"><span class="typing-dots"><span></span><span></span><span></span></span></span>';
             list.appendChild(m);
             scrollBottom();
             return m;
         }
 
-        function addBot(text, system){
+        function addBot(text, system, ts){
             const m = document.createElement('div');
             m.className = 'ai-agent-msg bot' + (system ? ' system' : '');
             m.dataset.role = 'assistant';
-            m.dataset.ts = Date.now();
-            m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ' + text;
+            m.dataset.ts = ts || Date.now();
+            m.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"></span>';
+            m.querySelector('.wpai-msg').textContent = text;
             list.appendChild(m);
             scrollBottom();
-            saveLocal();
+            persistConversation();
         }
 
         function renderConversation(conv){
             conv.forEach(function(m){
+                const text = m.content || m.message || m.text || '';
                 if(m.role === 'user'){
-                    addUser(m.content);
+                    addUser(text, m.ts);
                 } else if(m.system){
-                    addBot(m.content, true);
+                    addBot(text, true, m.ts);
                 } else {
-                    addBot(m.content);
+                    addBot(text, false, m.ts);
                 }
             });
         }
@@ -187,7 +192,7 @@
                     convo = data.conversation;
                     list.innerHTML = '';
                     renderConversation(convo);
-                    saveLocal();
+                    persistConversation();
                 }
                 if(data.status === 'active'){
                     startExpiry();
@@ -197,50 +202,51 @@
             } catch(e){}
         }
 
-        async function sendMsg(msg){
+        async function sendMsg(msg, userTs){
             if(finished){ finished = false; convo = []; localStorage.removeItem(storeKey); }
             startExpiry();
             const typingEl = showTyping();
             ta.disabled = true;
             send.disabled = true;
-            let textNode;
+            let msgSpan;
             try{
                 const full = await window.WPAI.sendChatRequest({
                     url: ajax + '?action=ai_agent_chat',
                     headers: { 'Content-Type': 'application/json' },
                     body: { visitor: visitor, message: msg, conversation: convo },
                     onToken: function(tok){
-                        if(!textNode){
+                        if(!msgSpan){
                             typingEl.classList.remove('typing');
-                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> ';
-                            textNode = document.createTextNode(tok);
-                            typingEl.appendChild(textNode);
-                        } else {
-                            textNode.textContent += tok;
+                            typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"></span>';
+                            msgSpan = typingEl.querySelector('.wpai-msg');
                         }
+                        msgSpan.textContent += tok;
                         scrollBottom();
                     },
                     onDone: function(){ startExpiry(); }
                 });
-                convo.push({role:'user',content:msg});
-                convo.push({role:'assistant',content:full});
-                if(!textNode){
+                convo.push({role:'user',content:msg,ts:userTs});
+                if(full){
+                    convo.push({role:'assistant',content:full,ts:parseInt(typingEl.dataset.ts,10)});
+                }
+                if(!msgSpan){
                     typingEl.classList.remove('typing');
-                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> '+full;
+                    typingEl.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg"></span>';
+                    typingEl.querySelector('.wpai-msg').textContent = full;
                 }
                 try{
                     const q = JSON.parse(full);
                     if(q && q.items){
                         renderQuote(q);
-                        if(textNode){ textNode.textContent = ''; }
+                        if(msgSpan){ msgSpan.textContent = ''; } else { typingEl.querySelector('.wpai-msg').textContent = ''; }
                     }
                 }catch(e){}
-                saveLocal();
+                persistConversation();
             } catch(e){
                 typingEl.remove();
                 const err = document.createElement('div');
                 err.className = 'ai-agent-msg bot';
-                err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> Error';
+                err.innerHTML = '<span class="ai-agent-name">'+agentName+':</span> <span class="wpai-msg">Error</span>';
                 list.appendChild(err);
                 scrollBottom();
             } finally {
@@ -254,8 +260,8 @@
             const msg = ta.value.trim();
             if(!msg){ return; }
             ta.value = '';
-            addUser(msg);
-            sendMsg(msg);
+            const el = addUser(msg);
+            sendMsg(msg, parseInt(el.dataset.ts,10));
         });
 
         if(config.enterSend){

--- a/wp-ai-agent/includes/class-ai-agent-ajax.php
+++ b/wp-ai-agent/includes/class-ai-agent-ajax.php
@@ -59,10 +59,17 @@ class Ai_Agent_AJAX {
         header( 'Cache-Control: no-cache' );
         header( 'X-Accel-Buffering: no' );
 
-        $response      = $this->stream_api( $settings, $messages );
+        ignore_user_abort( true );
+        @set_time_limit( 0 );
+
         $conversation[] = [ 'role' => 'user', 'content' => $message, 'ts' => time() ];
-        $conversation[] = [ 'role' => 'assistant', 'content' => $response, 'ts' => time() ];
-        Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
+        $chat_id = Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
+
+        $assistant = $this->stream_api( $settings, $messages );
+        if ( $assistant !== '' ) {
+            $conversation[] = [ 'role' => 'assistant', 'content' => $assistant, 'ts' => time() ];
+            Ai_Agent_DB::save_chat( $visitor, $ip_hash, $conversation, $chat_id );
+        }
         wp_die();
     }
 
@@ -109,39 +116,44 @@ class Ai_Agent_AJAX {
             'Content-Type: application/json',
             'Authorization: Bearer ' . ( $alt ? $alt : $open ),
         ];
+        $max_tokens = isset( $settings['max_tokens'] ) ? max( 800, (int) $settings['max_tokens'] ) : 800;
         $body = [
-            'model'    => $alt ? $model : $model,
-            'messages' => $messages,
-            'stream'   => true,
+            'model'       => $alt ? $model : $model,
+            'messages'    => $messages,
+            'stream'      => true,
+            'max_tokens'  => $max_tokens,
+            'temperature' => 0.7,
         ];
         $ch = curl_init( $url );
         curl_setopt( $ch, CURLOPT_HTTPHEADER, $headers );
         curl_setopt( $ch, CURLOPT_POST, true );
         curl_setopt( $ch, CURLOPT_POSTFIELDS, wp_json_encode( $body ) );
         curl_setopt( $ch, CURLOPT_RETURNTRANSFER, false );
-        $buffer = '';
-        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$buffer ) {
-            $buffer .= $data;
+        $assistant_buffer = '';
+        $line_buffer = '';
+        curl_setopt( $ch, CURLOPT_WRITEFUNCTION, function( $ch, $data ) use ( &$assistant_buffer, &$line_buffer ) {
             echo $data;
             @ob_flush();
             flush();
+            $line_buffer .= $data;
+            while ( false !== ( $pos = strpos( $line_buffer, "\n" ) ) ) {
+                $line = substr( $line_buffer, 0, $pos );
+                $line_buffer = substr( $line_buffer, $pos + 1 );
+                if ( 0 === strpos( $line, 'data:' ) ) {
+                    $payload = trim( substr( $line, 5 ) );
+                    if ( '[DONE]' === $payload ) {
+                        continue;
+                    }
+                    $json = json_decode( $payload, true );
+                    if ( isset( $json['choices'][0]['delta']['content'] ) ) {
+                        $assistant_buffer .= $json['choices'][0]['delta']['content'];
+                    }
+                }
+            }
             return strlen( $data );
         } );
         curl_exec( $ch );
         curl_close( $ch );
-        $text = '';
-        foreach ( explode( "\\n", $buffer ) as $line ) {
-            if ( 0 === strpos( $line, 'data:' ) ) {
-                $payload = trim( substr( $line, 5 ) );
-                if ( '[DONE]' === $payload ) {
-                    break;
-                }
-                $json = json_decode( $payload, true );
-                if ( isset( $json['choices'][0]['delta']['content'] ) ) {
-                    $text .= $json['choices'][0]['delta']['content'];
-                }
-            }
-        }
-        return $text;
+        return $assistant_buffer;
     }
 }


### PR DESCRIPTION
## Summary
- Accumulate streamed assistant replies server-side and persist both user and assistant messages once streaming finishes
- Increase chat completion limits and improve SSE handling for full message delivery
- Rewrite frontend stream reader, ensure full text persistence to localStorage, and avoid blank bubbles

## Testing
- `php -l includes/class-ai-agent-ajax.php`
- `node -e "new Function(require('fs').readFileSync('assets/js/chat.js','utf8')); console.log('chat.js ok')"`
- `node -e "new Function(require('fs').readFileSync('assets/js/chat-transport.js','utf8')); console.log('transport ok')"`


------
https://chatgpt.com/codex/tasks/task_e_689b3d1b8d5483209069ea09ec82e97d