### PR TITLE
fix: responsive chat widget (mobile/ipad/desktop)

### DIFF
--- a/wp-ai-agent/assets/css/chat.css
+++ b/wp-ai-agent/assets/css/chat.css
@@ -1,14 +1,66 @@
-[data-wpai-chat-root] { position: fixed; bottom: 20px; right: 20px; z-index: 99999; }
-.ai-agent-button { background:#25D366;color:#fff;border-radius:50%;width:56px;height:56px;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 2px 6px rgba(0,0,0,0.2); }
-.ai-agent-window { display:none; flex-direction:column; width:400px; height:600px; background:#fff; border:1px solid #ccc; border-radius:8px; overflow:hidden; }
-.ai-agent-header { background:#075e54; color:#fff; padding:10px; }
-.ai-agent-messages { flex:1; overflow-y:auto; padding:10px; background:url('../img/wallpaper.svg'); }
-.ai-agent-input { display:flex; }
-.ai-agent-input textarea { flex:1; }
-.ai-agent-msg.user { background:#DCF8C6; align-self:flex-end; }
-.ai-agent-msg.bot { background:#fff; align-self:flex-start; }
-.ai-agent-msg { padding:6px 8px; margin:4px; border-radius:6px; max-width:80%; }
-@media (max-width:767px){ .ai-agent-window{ width:100%; height:100vh; border-radius:0; right:0; bottom:0; }}
+/* variables */
+:root { --wpai-margin: 16px; }
+
+/* fixed position (bottom-right) with iOS safe areas */
+[data-wpai-chat-root] {
+  position: fixed;
+  right: calc(var(--wpai-margin) + env(safe-area-inset-right));
+  bottom: calc(var(--wpai-margin) + env(safe-area-inset-bottom));
+  z-index: 999999;
+}
+
+.ai-agent-button {
+  background:#25D366;
+  color:#fff;
+  border-radius:50%;
+  width:56px;
+  height:56px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  box-shadow:0 2px 6px rgba(0,0,0,0.2);
+}
+
+/* main chat panel */
+.ai-agent-window {
+  display:none;
+  flex-direction:column;
+  width:clamp(320px,92vw,420px);
+  height:clamp(420px,75dvh,640px);
+  max-height:calc(100dvh - (2 * var(--wpai-margin)) - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+  overflow:hidden;
+  border-radius:16px;
+  background:#fff;
+  border:1px solid #ccc;
+}
+
+/* iPad */
+@media (min-width:768px) and (max-width:1023.98px){
+  .ai-agent-window{
+    width:clamp(360px,60vw,520px);
+    height:clamp(520px,78dvh,760px);
+  }
+}
+
+/* Desktop */
+@media (min-width:1024px){
+  .ai-agent-window{ width:420px; height:640px; }
+}
+
+/* Fallback for older Safari that lacks dvh */
+@supports not (height:100dvh){
+  .ai-agent-window{ height:calc(100vh - (2 * var(--wpai-margin))); }
+}
+
+/* Make header/body/footer adapt without overflow */
+.ai-agent-header{ background:#075e54;color:#fff;padding:10px;flex:0 0 auto; }
+.ai-agent-messages{ flex:1 1 auto;min-height:0;overflow-y:auto;padding:10px;background:url('../img/wallpaper.svg'); }
+.ai-agent-input{ display:flex;flex:0 0 auto;padding-bottom:env(safe-area-inset-bottom); }
+.ai-agent-input textarea{ flex:1; }
+.ai-agent-msg.user{ background:#DCF8C6;align-self:flex-end; }
+.ai-agent-msg.bot{ background:#fff;align-self:flex-start; }
+.ai-agent-msg{ padding:6px 8px;margin:4px;border-radius:6px;max-width:80%; }
 
 .ai-agent-msg.typing { opacity:0.8; }
 .ai-agent-msg.typing .typing-dots { display:inline-block; margin-left:4px; }
@@ -25,4 +77,11 @@
 
 .ai-agent-msg.bot.system{background:#f1f1f1;font-style:italic;}
 .ai-agent-finished{margin:8px 4px;text-align:left;}
-.ai-agent-finished .ai-agent-btn-new{background:#34B7F1;color:#fff;border:none;padding:6px 12px;border-radius:6px;cursor:pointer;}
+.ai-agent-finished .ai-agent-btn-new{
+  background:#34B7F1;
+  color:#fff;
+  border:none;
+  padding:6px 12px;
+  border-radius:6px;
+  cursor:pointer;
+}


### PR DESCRIPTION
## Summary
- make chat widget container respect iOS safe areas and use CSS variable margin
- apply responsive clamp sizing to chat panel with desktop/iPad/phone media queries and Safari fallback
- ensure header, message list, and footer flex correctly and stay above iOS home bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7d4f4e048320bbffad74b9b65647